### PR TITLE
fix: move wrtc to optionalDependencies

### DIFF
--- a/skill/package.json
+++ b/skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "f2a-network-skill",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "F2A (Friend-to-Agent) P2P networking skill for OpenClaw with E2E encryption, WebRTC, and group chat support",
   "main": "scripts/index.js",
   "scripts": {
@@ -13,7 +13,9 @@
     "test:skills": "node tests/skills.test.js"
   },
   "dependencies": {
-    "ws": "^8.16.0",
+    "ws": "^8.16.0"
+  },
+  "optionalDependencies": {
     "wrtc": "^0.4.7"
   },
   "engines": {


### PR DESCRIPTION
## 问题

`wrtc` 原生模块在 macOS arm64 上经常编译失败，导致 `npm install` 报错退出。

## 解决方案

将 `wrtc` 从 `dependencies` 移到 `optionalDependencies`。

核心功能 `ServerlessP2P` 使用 Node.js 原生模块 (TCP/UDP)，不依赖 wrtc。wrtc 只用于 WebRTC 升级连接，是可选功能。

## 测试

```bash
cd skill
rm -rf node_modules package-lock.json
npm install  # ✅ 成功安装，wrtc 失败但不阻止
```

```
[ServerlessP2P] TCP listener on port 19001
[ServerlessP2P] UDP discovery on port 8767
[ServerlessP2P] Started on port 19001
✅ All good!
```

## 变更

- `wrtc` -> `optionalDependencies`
- 版本 0.3.0 -> 0.3.1