### PR TITLE
fix: add bin, test:coverage, prepare script, engines to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,32 @@
   "description": "Friend-to-Agent P2P networking protocol for OpenClaw Agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "bin": {
+    "f2a": "./dist/cli/index.js"
+  },
   "scripts": {
     "build": "tsc",
     "build:watch": "tsc --watch",
     "clean": "rm -rf dist",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "prepare": "npm run build"
   },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "keywords": [
+    "p2p",
+    "libp2p",
+    "agent",
+    "openclaw",
+    "networking"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LuciusCao/F2A.git"
+  },
+  "license": "MIT",
   "dependencies": {
     "@libp2p/crypto": "^4.0.0",
     "@libp2p/interface": "^1.0.0",


### PR DESCRIPTION
## 修复内容

### package.json 改进

| 新增项 | 说明 |
|--------|------|
| `bin` | CLI 入口，支持 `f2a` 命令 |
| `test:coverage` | 测试覆盖率脚本 |
| `prepare` | 安装时自动构建 |
| `engines` | Node.js 版本要求 (>=18) |
| `keywords` | npm 搜索关键词 |
| `repository` | Git 仓库地址 |
| `license` | MIT 许可证 |

### 使用方式

```bash
# 安装后自动构建
npm install

# 使用 CLI
npx f2a status

# 或全局安装后
npm link
f2a status

# 测试覆盖率
npm run test:coverage
```

---

**文件变更：** package.json (+22 行)