### PR TITLE
feat(reputation): Phase 1 - 基础信誉系统

### DIFF
--- a/src/core/reputation.test.ts
+++ b/src/core/reputation.test.ts
@@ -1,0 +1,260 @@
+/**
+ * 信誉系统测试
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ReputationManager, REPUTATION_TIERS, ReputationLevel } from './reputation';
+
+describe('ReputationManager', () => {
+  let manager: ReputationManager;
+
+  beforeEach(() => {
+    manager = new ReputationManager();
+  });
+
+  describe('初始信誉', () => {
+    it('should assign initial score of 70', () => {
+      const entry = manager.getReputation('peer-1');
+      expect(entry.score).toBe(70);
+      expect(entry.level).toBe('contributor');
+    });
+
+    it('should create same entry for same peer', () => {
+      const entry1 = manager.getReputation('peer-1');
+      const entry2 = manager.getReputation('peer-1');
+      expect(entry1).toBe(entry2);
+    });
+
+    it('should create different entries for different peers', () => {
+      const entry1 = manager.getReputation('peer-1');
+      const entry2 = manager.getReputation('peer-2');
+      expect(entry1).not.toBe(entry2);
+      expect(entry1.peerId).toBe('peer-1');
+      expect(entry2.peerId).toBe('peer-2');
+    });
+  });
+
+  describe('信誉等级', () => {
+    it('should return correct tier for score', () => {
+      const tier0 = manager.getTier(10);
+      expect(tier0.level).toBe('restricted');
+
+      const tier1 = manager.getTier(30);
+      expect(tier1.level).toBe('novice');
+
+      const tier2 = manager.getTier(50);
+      expect(tier2.level).toBe('participant');
+
+      const tier3 = manager.getTier(70);
+      expect(tier3.level).toBe('contributor');
+
+      const tier4 = manager.getTier(90);
+      expect(tier4.level).toBe('core');
+    });
+
+    it('should have correct permissions for each tier', () => {
+      // restricted
+      expect(manager.getTier(10).permissions.canPublish).toBe(false);
+      expect(manager.getTier(10).permissions.canExecute).toBe(true);
+      expect(manager.getTier(10).permissions.canReview).toBe(false);
+
+      // novice
+      expect(manager.getTier(30).permissions.canPublish).toBe(true);
+      expect(manager.getTier(30).permissions.canReview).toBe(false);
+
+      // participant+
+      expect(manager.getTier(50).permissions.canReview).toBe(true);
+
+      // contributor
+      expect(manager.getTier(70).permissions.publishDiscount).toBe(0.9);
+
+      // core
+      expect(manager.getTier(90).permissions.publishDiscount).toBe(0.7);
+      expect(manager.getTier(90).permissions.publishPriority).toBe(5);
+    });
+  });
+
+  describe('权限检查', () => {
+    it('should check publish permission correctly', () => {
+      // 70 分应该可以发布
+      expect(manager.hasPermission('peer-1', 'publish')).toBe(true);
+
+      // 降低到受限者
+      manager.recordFailure('peer-1', 'task-1', 'test');
+      manager.recordFailure('peer-1', 'task-2', 'test');
+      manager.recordFailure('peer-1', 'task-3', 'test');
+      manager.recordFailure('peer-1', 'task-4', 'test');
+      
+      // 多次失败后可能降到受限者
+      const entry = manager.getReputation('peer-1');
+      if (entry.score < 20) {
+        expect(manager.hasPermission('peer-1', 'publish')).toBe(false);
+      }
+    });
+
+    it('should always allow execute permission', () => {
+      expect(manager.hasPermission('peer-1', 'execute')).toBe(true);
+    });
+
+    it('should check review permission correctly', () => {
+      // 70 分是参与者，可以评审
+      expect(manager.hasPermission('peer-1', 'review')).toBe(true);
+    });
+  });
+
+  describe('EWMA 分数更新', () => {
+    it('should update score with EWMA on success', () => {
+      manager.recordSuccess('peer-1', 'task-1');
+      const entry = manager.getReputation('peer-1');
+      
+      // EWMA: newScore = 0.3 * 80 + 0.7 * 70 = 24 + 49 = 73
+      expect(entry.score).toBeCloseTo(73, 1);
+    });
+
+    it('should update score with EWMA on failure', () => {
+      manager.recordFailure('peer-1', 'task-1', 'test');
+      const entry = manager.getReputation('peer-1');
+      
+      // EWMA: newScore = 0.3 * 50 + 0.7 * 70 = 15 + 49 = 64
+      expect(entry.score).toBeCloseTo(64, 1);
+    });
+
+    it('should cap score at 100', () => {
+      // 多次成功应该封顶在 100
+      for (let i = 0; i < 20; i++) {
+        manager.recordSuccess('peer-1', `task-${i}`);
+      }
+      const entry = manager.getReputation('peer-1');
+      expect(entry.score).toBeLessThanOrEqual(100);
+    });
+
+    it('should not go below 0', () => {
+      // 多次失败应该保底在 0
+      for (let i = 0; i < 20; i++) {
+        manager.recordFailure('peer-1', `task-${i}`, 'test');
+      }
+      const entry = manager.getReputation('peer-1');
+      expect(entry.score).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('事件历史', () => {
+    it('should record success events', () => {
+      manager.recordSuccess('peer-1', 'task-1');
+      const entry = manager.getReputation('peer-1');
+      
+      expect(entry.history.length).toBe(2); // initial + success
+      expect(entry.history[1].type).toBe('task_success');
+      expect(entry.history[1].taskId).toBe('task-1');
+    });
+
+    it('should record failure events with reason', () => {
+      manager.recordFailure('peer-1', 'task-1', 'timeout');
+      const entry = manager.getReputation('peer-1');
+      
+      expect(entry.history.length).toBe(2);
+      expect(entry.history[1].type).toBe('task_failure');
+      expect(entry.history[1].reason).toBe('timeout');
+    });
+
+    it('should record rejection events', () => {
+      manager.recordRejection('peer-1', 'task-1', 'busy');
+      const entry = manager.getReputation('peer-1');
+      
+      expect(entry.history.some(e => e.type === 'task_rejected')).toBe(true);
+    });
+
+    it('should record review rewards', () => {
+      manager.recordReviewReward('peer-1', 3);
+      const entry = manager.getReputation('peer-1');
+      
+      expect(entry.history.some(e => e.type === 'review_given')).toBe(true);
+    });
+
+    it('should record review penalties', () => {
+      manager.recordReviewPenalty('peer-1', -5, 'outlier');
+      const entry = manager.getReputation('peer-1');
+      
+      expect(entry.history.some(e => e.type === 'review_penalty')).toBe(true);
+    });
+  });
+
+  describe('排序和查询', () => {
+    it('should return reputations sorted by score', () => {
+      manager.recordSuccess('peer-1', 'task-1');
+      manager.recordFailure('peer-2', 'task-2', 'test');
+      manager.recordSuccess('peer-3', 'task-3');
+      manager.recordSuccess('peer-3', 'task-4');
+
+      const all = manager.getAllReputations();
+      expect(all[0].score).toBeGreaterThanOrEqual(all[1].score);
+      expect(all[1].score).toBeGreaterThanOrEqual(all[2].score);
+    });
+
+    it('should filter high reputation nodes', () => {
+      // peer-1 保持高信誉
+      manager.recordSuccess('peer-1', 'task-1');
+      
+      // peer-2 降低信誉
+      for (let i = 0; i < 5; i++) {
+        manager.recordFailure('peer-2', `task-${i}`, 'test');
+      }
+
+      const highReputation = manager.getHighReputationNodes(50);
+      expect(highReputation.some(e => e.peerId === 'peer-1')).toBe(true);
+    });
+  });
+
+  describe('发布折扣和优先级', () => {
+    it('should return correct publish discount', () => {
+      // 70 分是 contributor，折扣 0.9
+      expect(manager.getPublishDiscount('peer-1')).toBe(0.9);
+
+      // 提升到 core
+      for (let i = 0; i < 10; i++) {
+        manager.recordSuccess('peer-1', `task-${i}`);
+      }
+      const entry = manager.getReputation('peer-1');
+      if (entry.level === 'core') {
+        expect(manager.getPublishDiscount('peer-1')).toBe(0.7);
+      }
+    });
+
+    it('should return correct publish priority', () => {
+      // 70 分是 contributor，优先级 3
+      expect(manager.getPublishPriority('peer-1')).toBe(3);
+    });
+  });
+
+  describe('自定义配置', () => {
+    it('should use custom initial score', () => {
+      const customManager = new ReputationManager({ initialScore: 50 });
+      const entry = customManager.getReputation('peer-1');
+      expect(entry.score).toBe(50);
+    });
+
+    it('should use custom alpha for EWMA', () => {
+      const customManager = new ReputationManager({ alpha: 0.5 });
+      customManager.recordSuccess('peer-1', 'task-1');
+      const entry = customManager.getReputation('peer-1');
+      
+      // EWMA: newScore = 0.5 * 80 + 0.5 * 70 = 40 + 35 = 75
+      expect(entry.score).toBeCloseTo(75, 1);
+    });
+  });
+});
+
+describe('REPUTATION_TIERS', () => {
+  it('should have 5 tiers', () => {
+    expect(REPUTATION_TIERS.length).toBe(5);
+  });
+
+  it('should cover all score ranges', () => {
+    const levels = REPUTATION_TIERS.map(t => t.level);
+    expect(levels).toContain('restricted');
+    expect(levels).toContain('novice');
+    expect(levels).toContain('participant');
+    expect(levels).toContain('contributor');
+    expect(levels).toContain('core');
+  });
+});

--- a/src/core/reputation.ts
+++ b/src/core/reputation.ts
@@ -1,0 +1,377 @@
+/**
+ * F2A 信誉系统
+ * Phase 1: 基础信誉管理
+ */
+
+import { Logger } from '../utils/logger';
+
+// ============================================================================
+// 类型定义
+// ============================================================================
+
+export type ReputationLevel = 'restricted' | 'novice' | 'participant' | 'contributor' | 'core';
+
+export interface ReputationTier {
+  min: number;
+  max: number;
+  level: ReputationLevel;
+  title: string;
+  permissions: {
+    canPublish: boolean;
+    canExecute: boolean;
+    canReview: boolean;
+    publishPriority: number;
+    publishDiscount: number;
+  };
+}
+
+export interface ReputationEntry {
+  peerId: string;
+  score: number;
+  level: ReputationLevel;
+  lastUpdated: number;
+  history: ReputationEvent[];
+}
+
+export interface ReputationEvent {
+  type: 'task_success' | 'task_failure' | 'task_rejected' | 'review_given' | 'review_penalty' | 'initial';
+  delta: number;
+  timestamp: number;
+  reason?: string;
+  taskId?: string;
+}
+
+export interface ReputationConfig {
+  initialScore: number;
+  alpha: number;  // EWMA 平滑系数
+  minScore: number;
+  maxScore: number;
+}
+
+// ============================================================================
+// 信誉等级定义
+// ============================================================================
+
+export const REPUTATION_TIERS: ReputationTier[] = [
+  {
+    min: 0,
+    max: 20,
+    level: 'restricted',
+    title: '受限者',
+    permissions: {
+      canPublish: false,
+      canExecute: true,
+      canReview: false,
+      publishPriority: 0,
+      publishDiscount: 1.0,
+    },
+  },
+  {
+    min: 20,
+    max: 40,
+    level: 'novice',
+    title: '新手',
+    permissions: {
+      canPublish: true,
+      canExecute: true,
+      canReview: false,
+      publishPriority: 1,
+      publishDiscount: 1.0,
+    },
+  },
+  {
+    min: 40,
+    max: 60,
+    level: 'participant',
+    title: '参与者',
+    permissions: {
+      canPublish: true,
+      canExecute: true,
+      canReview: true,
+      publishPriority: 2,
+      publishDiscount: 1.0,
+    },
+  },
+  {
+    min: 60,
+    max: 80,
+    level: 'contributor',
+    title: '贡献者',
+    permissions: {
+      canPublish: true,
+      canExecute: true,
+      canReview: true,
+      publishPriority: 3,
+      publishDiscount: 0.9,
+    },
+  },
+  {
+    min: 80,
+    max: 100,
+    level: 'core',
+    title: '核心成员',
+    permissions: {
+      canPublish: true,
+      canExecute: true,
+      canReview: true,
+      publishPriority: 5,
+      publishDiscount: 0.7,
+    },
+  },
+];
+
+// ============================================================================
+// 默认配置
+// ============================================================================
+
+const DEFAULT_CONFIG: ReputationConfig = {
+  initialScore: 70,
+  alpha: 0.3,
+  minScore: 0,
+  maxScore: 100,
+};
+
+// ============================================================================
+// 信誉管理器
+// ============================================================================
+
+export class ReputationManager {
+  private config: ReputationConfig;
+  private entries: Map<string, ReputationEntry> = new Map();
+  private logger: Logger;
+
+  constructor(config: Partial<ReputationConfig> = {}) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+    this.logger = new Logger({ component: 'Reputation' });
+  }
+
+  /**
+   * 获取节点信誉
+   */
+  getReputation(peerId: string): ReputationEntry {
+    if (!this.entries.has(peerId)) {
+      this.entries.set(peerId, this.createInitialEntry(peerId));
+    }
+    return this.entries.get(peerId)!;
+  }
+
+  /**
+   * 获取信誉等级
+   */
+  getTier(score: number): ReputationTier {
+    for (const tier of REPUTATION_TIERS) {
+      if (score >= tier.min && score < tier.max) {
+        return tier;
+      }
+    }
+    return REPUTATION_TIERS[REPUTATION_TIERS.length - 1]; // core
+  }
+
+  /**
+   * 检查权限
+   */
+  hasPermission(peerId: string, permission: 'publish' | 'execute' | 'review'): boolean {
+    const entry = this.getReputation(peerId);
+    const tier = this.getTier(entry.score);
+
+    switch (permission) {
+      case 'publish':
+        return tier.permissions.canPublish;
+      case 'execute':
+        return tier.permissions.canExecute;
+      case 'review':
+        return tier.permissions.canReview;
+    }
+  }
+
+  /**
+   * 记录任务成功
+   */
+  recordSuccess(peerId: string, taskId: string, delta: number = 10): void {
+    const entry = this.getReputation(peerId);
+    const newScore = this.updateScoreEWMA(entry.score, delta);
+
+    entry.score = newScore;
+    entry.level = this.getTier(newScore).level;
+    entry.lastUpdated = Date.now();
+    entry.history.push({
+      type: 'task_success',
+      delta,
+      timestamp: Date.now(),
+      taskId,
+    });
+
+    this.logger.info('Reputation updated', {
+      peerId: peerId.slice(0, 16),
+      delta,
+      newScore,
+      level: entry.level,
+    });
+  }
+
+  /**
+   * 记录任务失败
+   */
+  recordFailure(peerId: string, taskId: string, reason?: string, delta: number = -20): void {
+    const entry = this.getReputation(peerId);
+    const newScore = this.updateScoreEWMA(entry.score, delta);
+
+    entry.score = newScore;
+    entry.level = this.getTier(newScore).level;
+    entry.lastUpdated = Date.now();
+    entry.history.push({
+      type: 'task_failure',
+      delta,
+      timestamp: Date.now(),
+      reason,
+      taskId,
+    });
+
+    this.logger.warn('Reputation decreased', {
+      peerId: peerId.slice(0, 16),
+      delta,
+      newScore,
+      level: entry.level,
+      reason,
+    });
+  }
+
+  /**
+   * 记录任务拒绝
+   */
+  recordRejection(peerId: string, taskId: string, reason?: string, delta: number = -5): void {
+    const entry = this.getReputation(peerId);
+    const newScore = this.updateScoreEWMA(entry.score, delta);
+
+    entry.score = newScore;
+    entry.level = this.getTier(newScore).level;
+    entry.lastUpdated = Date.now();
+    entry.history.push({
+      type: 'task_rejected',
+      delta,
+      timestamp: Date.now(),
+      reason,
+      taskId,
+    });
+
+    this.logger.info('Reputation updated (rejection)', {
+      peerId: peerId.slice(0, 16),
+      delta,
+      newScore,
+    });
+  }
+
+  /**
+   * 记录评审奖励
+   */
+  recordReviewReward(peerId: string, delta: number = 3): void {
+    const entry = this.getReputation(peerId);
+    const newScore = this.updateScoreEWMA(entry.score, delta);
+
+    entry.score = newScore;
+    entry.level = this.getTier(newScore).level;
+    entry.lastUpdated = Date.now();
+    entry.history.push({
+      type: 'review_given',
+      delta,
+      timestamp: Date.now(),
+    });
+
+    this.logger.info('Review reward', {
+      peerId: peerId.slice(0, 16),
+      delta,
+      newScore,
+    });
+  }
+
+  /**
+   * 记录评审惩罚
+   */
+  recordReviewPenalty(peerId: string, delta: number = -5, reason?: string): void {
+    const entry = this.getReputation(peerId);
+    const newScore = this.updateScoreEWMA(entry.score, delta);
+
+    entry.score = newScore;
+    entry.level = this.getTier(newScore).level;
+    entry.lastUpdated = Date.now();
+    entry.history.push({
+      type: 'review_penalty',
+      delta,
+      timestamp: Date.now(),
+      reason,
+    });
+
+    this.logger.warn('Review penalty', {
+      peerId: peerId.slice(0, 16),
+      delta,
+      newScore,
+      reason,
+    });
+  }
+
+  /**
+   * 获取所有信誉条目（按分数排序）
+   */
+  getAllReputations(): ReputationEntry[] {
+    return Array.from(this.entries.values()).sort((a, b) => b.score - a.score);
+  }
+
+  /**
+   * 获取高信誉节点（可用于评审）
+   */
+  getHighReputationNodes(minScore: number = 50): ReputationEntry[] {
+    return this.getAllReputations().filter(e => e.score >= minScore);
+  }
+
+  /**
+   * 计算发布优先级
+   */
+  getPublishPriority(peerId: string): number {
+    const entry = this.getReputation(peerId);
+    return this.getTier(entry.score).permissions.publishPriority;
+  }
+
+  /**
+   * 计算发布折扣
+   */
+  getPublishDiscount(peerId: string): number {
+    const entry = this.getReputation(peerId);
+    return this.getTier(entry.score).permissions.publishDiscount;
+  }
+
+  // ============================================================================
+  // 私有方法
+  // ============================================================================
+
+  /**
+   * 创建初始信誉条目
+   */
+  private createInitialEntry(peerId: string): ReputationEntry {
+    return {
+      peerId,
+      score: this.config.initialScore,
+      level: this.getTier(this.config.initialScore).level,
+      lastUpdated: Date.now(),
+      history: [
+        {
+          type: 'initial',
+          delta: 0,
+          timestamp: Date.now(),
+        },
+      ],
+    };
+  }
+
+  /**
+   * EWMA 分数更新
+   * newScore = α * observation + (1 - α) * currentScore
+   */
+  private updateScoreEWMA(currentScore: number, delta: number): number {
+    const observation = currentScore + delta;
+    const newScore = this.config.alpha * observation + (1 - this.config.alpha) * currentScore;
+    return Math.max(this.config.minScore, Math.min(this.config.maxScore, newScore));
+  }
+}
+
+// 默认导出
+export default ReputationManager;


### PR DESCRIPTION
## 概述

实现 RFC-001 Phase 1：基础信誉系统

## 实现内容

### 1. ReputationManager 核心类

```typescript
const manager = new ReputationManager();

// 获取信誉
const entry = manager.getReputation('peer-id');

// 记录事件
manager.recordSuccess('peer-id', 'task-1');
manager.recordFailure('peer-id', 'task-2', 'timeout');
manager.recordRejection('peer-id', 'task-3', 'busy');

// 检查权限
manager.hasPermission('peer-id', 'publish');
manager.hasPermission('peer-id', 'review');
```

### 2. EWMA 分数更新

```typescript
// α = 0.3
newScore = 0.3 * observation + 0.7 * currentScore
```

### 3. 信誉等级系统

| 分数 | 等级 | 发布 | 执行 | 评审 | 折扣 |
|-----|------|-----|-----|-----|-----|
| 0-20 | 受限者 | ❌ | ✅ | ❌ | - |
| 20-40 | 新手 | ✅ | ✅ | ❌ | 100% |
| 40-60 | 参与者 | ✅ | ✅ | ✅ | 100% |
| 60-80 | 贡献者 | ✅ | ✅ | ✅ | 90% |
| 80-100 | 核心成员 | ✅ | ✅ | ✅ | 70% |

### 4. 事件历史

- 任务成功 (+10)
- 任务失败 (-20)
- 任务拒绝 (-5)
- 评审奖励 (+3)
- 评审惩罚 (-5)

## 测试

- ✅ 25 个测试全部通过
- 覆盖：初始信誉、等级划分、权限检查、EWMA 更新、事件历史、排序查询

## 下一步

- Phase 2: 评审机制
- Phase 3: 安全机制
- Phase 4: 自治经济

---

🐱 RFC-001 Phase 1 实现