### PR TITLE
fix: stabilize integration test bootstrap endpoint resolution

### DIFF
--- a/tests/docker/docker-compose.test.yml
+++ b/tests/docker/docker-compose.test.yml
@@ -61,6 +61,7 @@ services:
       - f2a-test-net
     environment:
       - RUN_INTEGRATION_TESTS=true
+      - TEST_BOOTSTRAP_HTTP=http://bootstrap:9001
       - TEST_BOOTSTRAP_ADDR=/dns4/bootstrap.f2a.local/tcp/9000
       - TEST_NODE_COUNT=${NODE_COUNT:-3}
       - TEST_TOKEN=${TEST_TOKEN:-test-token-integration}

--- a/tests/integration/message-passing.test.ts
+++ b/tests/integration/message-passing.test.ts
@@ -4,12 +4,13 @@
  */
 
 import { describe, it, expect, beforeAll } from 'vitest';
+import { getBootstrapHttp } from './test-config';
 
 const shouldRun = process.env.RUN_INTEGRATION_TESTS === 'true';
 
 describe.skipIf(!shouldRun)('消息传递集成测试', () => {
   // 使用 HTTP URL 格式，而不是 libp2p 多地址
-  const bootstrapAddr = process.env.TEST_BOOTSTRAP_HTTP || 'http://bootstrap.f2a.local:9001';
+  const bootstrapAddr = getBootstrapHttp();
   const testToken = process.env.TEST_TOKEN || 'test-token-integration';
 
   beforeAll(async () => {

--- a/tests/integration/multi-node.test.ts
+++ b/tests/integration/multi-node.test.ts
@@ -4,12 +4,13 @@
  */
 
 import { describe, it, expect, beforeAll } from 'vitest';
+import { getBootstrapHttp } from './test-config';
 
 const shouldRun = process.env.RUN_INTEGRATION_TESTS === 'true';
 
 describe.skipIf(!shouldRun)('多节点压力测试', () => {
   // 使用 HTTP URL 格式，而不是 libp2p 多地址
-  const bootstrapAddr = process.env.TEST_BOOTSTRAP_HTTP || 'http://bootstrap.f2a.local:9001';
+  const bootstrapAddr = getBootstrapHttp();
   const nodeCount = parseInt(process.env.TEST_NODE_COUNT || '3');
   const testToken = process.env.TEST_TOKEN || 'test-token-integration';
 

--- a/tests/integration/p2p-connection.test.ts
+++ b/tests/integration/p2p-connection.test.ts
@@ -3,14 +3,15 @@
  * 测试节点之间的连接建立和发现
  */
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect } from 'vitest';
+import { getBootstrapHttp } from './test-config';
 
 // 只在集成测试环境运行
 const shouldRun = process.env.RUN_INTEGRATION_TESTS === 'true';
 
 describe.skipIf(!shouldRun)('P2P 连接集成测试', () => {
   // 使用 HTTP URL 格式，而不是 libp2p 多地址
-  const bootstrapAddr = process.env.TEST_BOOTSTRAP_HTTP || 'http://bootstrap.f2a.local:9001';
+  const bootstrapAddr = getBootstrapHttp();
   const nodeCount = parseInt(process.env.TEST_NODE_COUNT || '3');
   const testToken = process.env.TEST_TOKEN || 'test-token-integration';
 

--- a/tests/integration/test-config.ts
+++ b/tests/integration/test-config.ts
@@ -1,0 +1,32 @@
+const defaultBootstrapHttp = 'http://bootstrap:9001';
+
+function normalizeBootstrapUrl(raw: string): string {
+  if (raw.startsWith('http://') || raw.startsWith('https://')) {
+    return raw;
+  }
+
+  // 兼容 /dns4/bootstrap/tcp/9000 这样的多地址配置
+  const match = raw.match(/^\/dns4\/([^/]+)\/tcp\/(\d+)$/);
+  if (match) {
+    const [, host, port] = match;
+    const controlPort = port === '9000' ? '9001' : port;
+    return `http://${host}:${controlPort}`;
+  }
+
+  return raw;
+}
+
+export function getBootstrapHttp(): string {
+  const explicitHttp = process.env.TEST_BOOTSTRAP_HTTP;
+  if (explicitHttp) {
+    return normalizeBootstrapUrl(explicitHttp);
+  }
+
+  const bootstrapAddr = process.env.TEST_BOOTSTRAP_ADDR;
+  if (bootstrapAddr) {
+    return normalizeBootstrapUrl(bootstrapAddr);
+  }
+
+  return defaultBootstrapHttp;
+}
+


### PR DESCRIPTION
### Motivation
- Integration tests were failing in CI due to unstable bootstrap control endpoint resolution and relying on the DNS alias `bootstrap.f2a.local`, causing `ENOTFOUND` errors when tests used `http://bootstrap.f2a.local:9001`.
- Make the integration tests robust against multiaddr vs HTTP address formats and ensure docker runner points to a resolvable control API URL.

### Description
- Added `tests/integration/test-config.ts` which centralizes bootstrap URL resolution and converts multiaddrs like `/dns4/bootstrap.f2a.local/tcp/9000` to an HTTP control URL, with a safe default of `http://bootstrap:9001`.
- Updated integration suites (`tests/integration/p2p-connection.test.ts`, `tests/integration/message-passing.test.ts`, `tests/integration/multi-node.test.ts`) to use `getBootstrapHttp()` instead of a hardcoded default.
- Updated `tests/docker/docker-compose.test.yml` test-runner environment to explicitly set `TEST_BOOTSTRAP_HTTP=http://bootstrap:9001` to avoid fragile DNS alias lookups inside the CI Docker network.

### Testing
- Ran unit tests with `npm run test:unit`, and all unit tests passed (`263 passed`).
- Attempted `npm run test:docker` in this environment but it could not run because `docker` was not available (`docker: not found`).
- The changes address the `ENOTFOUND bootstrap.f2a.local` failures by preferring an explicit HTTP endpoint and by parsing multiaddr fallbacks for the integration runner.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa7173d46c83279588198ceb04d842)