### PR TITLE
Add middleware and DHT facades to F2A, improve P2P discovery & message handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ F2A 使用 Kademlia DHT 实现全局节点发现。
 const f2a = await F2A.create({
   displayName: 'My Agent',
   network: {
-    enableDHT: true,           // 启用 DHT (默认 true)
+    enableDHT: true,           // 启用 DHT (默认 false)
     dhtServerMode: false,      // 客户端模式 (默认)
     bootstrapPeers: [          // 可选：引导节点加速首次连接
       '/ip4/1.2.3.4/tcp/9000/p2p/12D3KooW...'

--- a/docs/security-design.md
+++ b/docs/security-design.md
@@ -113,7 +113,7 @@ F2A 采用多层安全机制，确保 Agent 间通信的机密性、完整性和
 ## 3. 安全等级配置
 
 ```javascript
-const f2a = new F2A({
+const f2a = await F2A.create({
   security: {
     // low: 仅加密，信任局域网
     // medium: 加密 + 白名单（默认）
@@ -199,7 +199,7 @@ const f2a = new F2A({
 ### 6.1 生产环境建议
 
 ```javascript
-const f2a = new F2A({
+const f2a = await F2A.create({
   security: {
     level: 'high',
     requireConfirmation: true,

--- a/src/core/f2a.test.ts
+++ b/src/core/f2a.test.ts
@@ -14,6 +14,12 @@ vi.mock('./p2p-network', () => ({
     getConnectedPeers: vi.fn().mockReturnValue([]),
     sendTaskRequest: vi.fn(),
     sendTaskResponse: vi.fn().mockResolvedValue({ success: true }),
+    useMiddleware: vi.fn(),
+    removeMiddleware: vi.fn().mockReturnValue(true),
+    listMiddlewares: vi.fn().mockReturnValue(['test-middleware']),
+    findPeerViaDHT: vi.fn().mockResolvedValue({ success: false, error: { code: 'DHT_NOT_AVAILABLE', message: 'DHT not enabled' } }),
+    getDHTPeerCount: vi.fn().mockReturnValue(0),
+    isDHTEnabled: vi.fn().mockReturnValue(false),
     on: vi.fn(),
     getPeerId: vi.fn().mockReturnValue('test-peer-id')
   }))
@@ -220,6 +226,28 @@ describe('F2A', () => {
         'Error message'
       );
       expect(result.success).toBe(true);
+    });
+  });
+
+  describe('middleware and DHT facade', () => {
+    it('should proxy middleware methods to p2p network', () => {
+      const middleware = {
+        name: 'test-middleware',
+        priority: 10,
+        process: vi.fn().mockResolvedValue({ action: 'continue' })
+      };
+
+      f2a.useMiddleware(middleware as any);
+      expect(f2a.listMiddlewares()).toEqual(['test-middleware']);
+      expect(f2a.removeMiddleware('test-middleware')).toBe(true);
+    });
+
+    it('should proxy dht methods to p2p network', async () => {
+      const lookup = await f2a.findPeerViaDHT('peer-id');
+      expect(lookup.success).toBe(false);
+      expect(lookup.error?.code).toBe('DHT_NOT_AVAILABLE');
+      expect(f2a.getDHTPeerCount()).toBe(0);
+      expect(f2a.isDHTEnabled()).toBe(false);
     });
   });
 

--- a/src/core/f2a.ts
+++ b/src/core/f2a.ts
@@ -6,6 +6,7 @@
 import { EventEmitter } from 'eventemitter3';
 import { P2PNetwork } from './p2p-network.js';
 import { Logger } from '../utils/logger.js';
+import { Middleware } from '../utils/middleware.js';
 import { validateAgentCapability, validateTaskDelegateOptions } from '../utils/validation.js';
 import {
   F2AOptions,
@@ -49,6 +50,16 @@ export interface F2AInstance {
 
   // 直接通信
   sendTaskTo(peerId: string, taskType: string, description: string, parameters?: Record<string, unknown>): Promise<Result<unknown>>;
+
+  // 中间件
+  useMiddleware(middleware: Middleware): void;
+  removeMiddleware(name: string): boolean;
+  listMiddlewares(): string[];
+
+  // DHT
+  findPeerViaDHT(peerId: string): Promise<Result<string[]>>;
+  getDHTPeerCount(): number;
+  isDHTEnabled(): boolean;
 }
 
 export class F2A extends EventEmitter<F2AEvents> implements F2AInstance {
@@ -357,6 +368,48 @@ export class F2A extends EventEmitter<F2AEvents> implements F2AInstance {
       parameters,
       30000
     );
+  }
+
+  /**
+   * 注册中间件
+   */
+  useMiddleware(middleware: Middleware): void {
+    this.p2pNetwork.useMiddleware(middleware);
+  }
+
+  /**
+   * 移除中间件
+   */
+  removeMiddleware(name: string): boolean {
+    return this.p2pNetwork.removeMiddleware(name);
+  }
+
+  /**
+   * 获取已注册中间件列表
+   */
+  listMiddlewares(): string[] {
+    return this.p2pNetwork.listMiddlewares();
+  }
+
+  /**
+   * 通过 DHT 查找节点
+   */
+  async findPeerViaDHT(peerId: string): Promise<Result<string[]>> {
+    return this.p2pNetwork.findPeerViaDHT(peerId);
+  }
+
+  /**
+   * 获取 DHT 路由表大小
+   */
+  getDHTPeerCount(): number {
+    return this.p2pNetwork.getDHTPeerCount();
+  }
+
+  /**
+   * 检查 DHT 是否启用
+   */
+  isDHTEnabled(): boolean {
+    return this.p2pNetwork.isDHTEnabled();
   }
 
   /**

--- a/src/core/p2p-network.test.ts
+++ b/src/core/p2p-network.test.ts
@@ -114,4 +114,86 @@ describe('P2PNetwork', () => {
       expect(error.message).toBe('Test error');
     });
   });
+
+  describe('message handling', () => {
+    it('should process DISCOVER_RESP and upsert peer', async () => {
+      const agentInfo: AgentInfo = {
+        ...mockAgentInfo,
+        peerId: 'peer-remote',
+        multiaddrs: ['/ip4/127.0.0.1/tcp/9002']
+      };
+
+      await (network as any).handleMessage(
+        {
+          id: '00000000-0000-4000-8000-000000000001',
+          type: 'DISCOVER_RESP',
+          from: 'peer-remote',
+          timestamp: Date.now(),
+          payload: { agentInfo }
+        },
+        'peer-remote'
+      );
+
+      const peers = network.getAllPeers();
+      expect(peers).toHaveLength(1);
+      expect(peers[0].agentInfo?.peerId).toBe('peer-remote');
+      expect(peers[0].multiaddrs[0].toString()).toContain('/tcp/9002');
+    });
+
+    it('should process CAPABILITY_RESPONSE and upsert peer', async () => {
+      const agentInfo: AgentInfo = {
+        ...mockAgentInfo,
+        peerId: 'peer-cap',
+        capabilities: [{ name: 'code-gen', description: 'Code Gen', tools: ['generate'] }],
+        multiaddrs: ['/ip4/127.0.0.1/tcp/9003']
+      };
+
+      await (network as any).handleMessage(
+        {
+          id: '00000000-0000-4000-8000-000000000002',
+          type: 'CAPABILITY_RESPONSE',
+          from: 'peer-cap',
+          timestamp: Date.now(),
+          payload: { agentInfo }
+        },
+        'peer-cap'
+      );
+
+      const peers = network.getAllPeers();
+      expect(peers).toHaveLength(1);
+      expect(peers[0].agentInfo?.capabilities[0].name).toBe('code-gen');
+    });
+  });
+
+  describe('broadcast', () => {
+    it('should count fulfilled failures in broadcast warning', async () => {
+      const warnSpy = vi.spyOn((network as any).logger, 'warn');
+
+      (network as any).node = {
+        getPeers: vi.fn().mockReturnValue([
+          { toString: () => 'peer-a' },
+          { toString: () => 'peer-b' }
+        ]),
+        stop: vi.fn().mockResolvedValue(undefined)
+      };
+
+      const sendSpy = vi.spyOn(network as any, 'sendMessage')
+        .mockResolvedValueOnce({ success: true, data: undefined })
+        .mockResolvedValueOnce({ success: false, error: { code: 'PEER_NOT_FOUND', message: 'Peer not found' } });
+
+      await (network as any).broadcast({
+        id: 'msg-broadcast',
+        type: 'DISCOVER',
+        from: 'self',
+        timestamp: Date.now(),
+        payload: { agentInfo: mockAgentInfo }
+      });
+
+      expect(sendSpy).toHaveBeenCalledTimes(2);
+      expect(warnSpy).toHaveBeenCalledWith('Broadcast failed to some peers', {
+        failed: 1,
+        total: 2
+      });
+    });
+  });
 });

--- a/src/core/p2p-network.ts
+++ b/src/core/p2p-network.ts
@@ -351,7 +351,10 @@ export class P2PNetwork extends EventEmitter<P2PNetworkEvents> {
     );
 
     // 记录发送失败的情况
-    const failures = results.filter(r => r.status === 'rejected');
+    const failures = results.filter(r =>
+      r.status === 'rejected' ||
+      (r.status === 'fulfilled' && !r.value.success)
+    );
     if (failures.length > 0) {
       this.logger.warn('Broadcast failed to some peers', {
         failed: failures.length,
@@ -543,13 +546,25 @@ export class P2PNetwork extends EventEmitter<P2PNetworkEvents> {
     switch (message.type) {
       case 'DISCOVER': {
         const payload = message.payload as DiscoverPayload;
-        await this.handleDiscover(payload.agentInfo, peerId);
+        await this.handleDiscover(payload.agentInfo, peerId, true);
+        break;
+      }
+
+      case 'DISCOVER_RESP': {
+        const payload = message.payload as DiscoverPayload;
+        await this.handleDiscover(payload.agentInfo, peerId, false);
         break;
       }
 
       case 'CAPABILITY_QUERY': {
         const payload = message.payload as CapabilityQueryPayload;
         await this.handleCapabilityQuery(payload, peerId);
+        break;
+      }
+
+      case 'CAPABILITY_RESPONSE': {
+        const payload = message.payload as CapabilityResponsePayload;
+        this.upsertPeerFromAgentInfo(payload.agentInfo, peerId);
         break;
       }
 
@@ -574,17 +589,49 @@ export class P2PNetwork extends EventEmitter<P2PNetworkEvents> {
   /**
    * 处理发现消息
    */
-  private async handleDiscover(agentInfo: AgentInfo, peerId: string): Promise<void> {
+  private async handleDiscover(agentInfo: AgentInfo, peerId: string, shouldRespond: boolean): Promise<void> {
+    this.upsertPeerFromAgentInfo(agentInfo, peerId);
+
+    // 仅对 DISCOVER 请求响应，避免发现响应循环
+    if (shouldRespond) {
+      const responseResult = await this.sendMessage(peerId, {
+        id: randomUUID(),
+        type: 'DISCOVER_RESP',
+        from: this.agentInfo.peerId,
+        to: peerId,
+        timestamp: Date.now(),
+        payload: { agentInfo: this.agentInfo } as DiscoverPayload
+      });
+
+      if (!responseResult.success) {
+        this.logger.warn('Failed to send discover response', {
+          peerId: peerId.slice(0, 16),
+          error: responseResult.error
+        });
+      }
+    }
+
+    this.emit('peer:discovered', {
+      peerId,
+      agentInfo,
+      multiaddrs: agentInfo.multiaddrs.map(ma => multiaddr(ma))
+    });
+  }
+
+  /**
+   * 将发现到的 Agent 信息更新到 Peer 表
+   */
+  private upsertPeerFromAgentInfo(agentInfo: AgentInfo, peerId: string): void {
     // 检查是否需要清理以腾出空间
     if (this.peerTable.size >= PEER_TABLE_MAX_SIZE && !this.peerTable.has(peerId)) {
       this.cleanupStalePeers(true); // 强制清理
     }
 
-    // 更新路由表
     const existing = this.peerTable.get(peerId);
     if (existing) {
       existing.agentInfo = agentInfo;
       existing.lastSeen = Date.now();
+      existing.multiaddrs = agentInfo.multiaddrs.map(ma => multiaddr(ma));
     } else {
       this.peerTable.set(peerId, {
         peerId,
@@ -601,29 +648,6 @@ export class P2PNetwork extends EventEmitter<P2PNetworkEvents> {
       this.e2eeCrypto.registerPeerPublicKey(peerId, agentInfo.encryptionPublicKey);
       this.logger.info('Registered encryption key', { peerId: peerId.slice(0, 16) });
     }
-
-    // 发送发现响应
-    const responseResult = await this.sendMessage(peerId, {
-      id: randomUUID(),
-      type: 'DISCOVER_RESP',
-      from: this.agentInfo.peerId,
-      to: peerId,
-      timestamp: Date.now(),
-      payload: { agentInfo: this.agentInfo } as DiscoverPayload
-    });
-
-    if (!responseResult.success) {
-      this.logger.warn('Failed to send discover response', {
-        peerId: peerId.slice(0, 16),
-        error: responseResult.error
-      });
-    }
-
-    this.emit('peer:discovered', {
-      peerId,
-      agentInfo,
-      multiaddrs: agentInfo.multiaddrs.map(ma => multiaddr(ma))
-    });
   }
 
   /**


### PR DESCRIPTION
### Motivation
- Expose middleware and DHT functionality from the underlying P2P layer through the `F2A` public API to allow higher-level code to register middlewares and perform DHT queries. 
- Fix discovery response handling to avoid response loops and ensure discovered peers are upserted with proper multiaddr and encryption key registration. 
- Improve broadcast failure detection to count RPC-level failures as well as rejected promises.

### Description
- Added middleware passthrough methods to `F2A`: `useMiddleware`, `removeMiddleware`, and `listMiddlewares`, and added DHT façade methods: `findPeerViaDHT`, `getDHTPeerCount`, and `isDHTEnabled` in `src/core/f2a.ts`.
- Enhanced `P2PNetwork` message processing in `src/core/p2p-network.ts` to handle `DISCOVER_RESP` and `CAPABILITY_RESPONSE`, split discovery handling into `handleDiscover(agentInfo, peerId, shouldRespond)` and `upsertPeerFromAgentInfo` to avoid discovery-response loops, register peer encryption keys, and emit `peer:discovered` with multiaddrs.
- Updated `broadcast` logic to treat fulfilled-but-failed RPC results as failures when computing warning counts.
- Adjusted examples/docs to use the async factory `await F2A.create(...)` and changed the README comment for `enableDHT` default to `false`.
- Tests updated and extended: `src/core/f2a.test.ts` mocks new P2PNetwork APIs and adds tests for middleware and DHT proxying, and `src/core/p2p-network.test.ts` adds tests for `DISCOVER_RESP`/`CAPABILITY_RESPONSE` handling and broadcast failure counting.

### Testing
- Ran unit tests with `vitest` covering `F2A` and `P2PNetwork` changes, including new middleware/DHT facade tests and message handling tests; all tests passed. 
- Verified added tests in `src/core/f2a.test.ts` and `src/core/p2p-network.test.ts` executed successfully under the test suite. 
- No integration or runtime regressions were detected by the unit test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa7500c8908327a20c023578ad3365)