### PR TITLE
ci: 避免 CI 重复运行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main, develop]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Lint 检查
   lint:


### PR DESCRIPTION
添加 concurrency 配置，当同一分支/PR 有新提交时取消旧的 CI 运行