### PR TITLE
fix: resolve code review issues from PR #59

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14672,7 +14672,7 @@
     },
     "packages/openclaw-adapter": {
       "name": "@f2a/openclaw-adapter",
-      "version": "0.1.2",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "@f2a/network": "^0.1.2",

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -1,22 +1,39 @@
 /**
+ * F2A CLI 配置管理
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync, chmodSync, copyFileSync, readdirSync, statSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { z } from 'zod';
+
+// ============================================================================
+// 常量
+// ============================================================================
+
+/**
  * Agent 名称过滤正则
  * 只允许字母、数字、连字符和下划线
  */
-const AGENT_NAME_REGEX = /^[a-zA-Z0-9_-]+$/;
+export const AGENT_NAME_REGEX = /^[a-zA-Z0-9_-]+$/;
 
 /**
  * Multiaddr 格式正则
- * 支持 /ip4/..., /ip6/..., /dns4/..., /dns6/..., /dnsaddr/... 等格式
+ * 支持 /ip4/..., /ip6/..., /dns/..., /dns4/..., /dns6/..., /dnsaddr/... 等格式
  * 必须包含 /p2p/<peer-id> 或 /ipfs/<peer-id>
  */
-const MULTIADDR_REGEX = /^\/(ip4|ip6|dns4|dns6|dnsaddr)(\/[a-zA-Z0-9.\-:]+)+\/(p2p|ipfs)\/[a-zA-Z0-9]+$/;
+export const MULTIADDR_REGEX = /^\/(ip4|ip6|dns|dns4|dns6|dnsaddr)(\/[a-zA-Z0-9.\-:]+)+\/(p2p|ipfs)\/[a-zA-Z0-9]+$/;
+
+// ============================================================================
+// 辅助函数
+// ============================================================================
 
 /**
  * 调试日志（仅在 DEBUG 模式下输出详细信息）
  */
 function debugLog(message: string, data?: unknown): void {
   if (process.env.F2A_DEBUG === 'true') {
-    console.error(`[F2A DEBUG] ${message}`, data !== undefined ? data : '');
+    console.warn(`[F2A DEBUG] ${message}`, data !== undefined ? data : '');
   }
 }
 
@@ -39,12 +56,12 @@ export function validateAgentName(name: string): { valid: boolean; error?: strin
 /**
  * 验证 multiaddr 格式
  */
-function validateMultiaddr(addr: string): { valid: boolean; error?: string } {
+export function validateMultiaddr(addr: string): { valid: boolean; error?: string } {
   if (!addr || typeof addr !== 'string') {
     return { valid: false, error: 'Invalid multiaddr: empty or not a string' };
   }
   if (!MULTIADDR_REGEX.test(addr)) {
-    return { valid: false, error: 'Invalid multiaddr format. Expected: /ip4|ip6|dns4|dns6|dnsaddr/<host>/p2p/<peer-id>' };
+    return { valid: false, error: 'Invalid multiaddr format. Expected: /ip4|ip6|dns|dns4|dns6|dnsaddr/<host>/p2p/<peer-id>' };
   }
   return { valid: true };
 }
@@ -53,7 +70,7 @@ function validateMultiaddr(addr: string): { valid: boolean; error?: string } {
  * 验证路径安全性
  * 禁止路径遍历（..）和危险字符
  */
-function validatePath(path: string): { valid: boolean; error?: string } {
+export function validatePath(path: string): { valid: boolean; error?: string } {
   if (!path || typeof path !== 'string') {
     return { valid: false, error: 'Invalid path: empty or not a string' };
   }
@@ -95,11 +112,6 @@ function cleanupOldBackups(configDir: string, keepCount: number = 5): void {
     // 清理失败不阻止保存
   }
 }
-
-import { existsSync, readFileSync, writeFileSync, mkdirSync, chmodSync, copyFileSync, readdirSync, statSync, unlinkSync } from 'fs';
-import { join } from 'path';
-import { homedir } from 'os';
-import { z } from 'zod';
 
 // ============================================================================
 // 配置 Schema
@@ -411,11 +423,11 @@ export function validateConfig(config: F2AConfig): { valid: boolean; missing: st
     }
   }
   
-  // 额外的 dataDir 路径安全验证
+  // 额外的 dataDir 路径安全验证（使用 validatePath 函数）
   if (config.dataDir) {
-    // 检测路径遍历攻击
-    if (config.dataDir.includes('..') || /[<>:"|?*\x00-\x1f]/.test(config.dataDir)) {
-      errors.push('dataDir: Path contains forbidden characters or traversal patterns');
+    const pathValidation = validatePath(config.dataDir);
+    if (!pathValidation.valid) {
+      errors.push(`dataDir: ${pathValidation.error}`);
     }
     // 必须是绝对路径
     if (!config.dataDir.startsWith('/')) {

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -13,14 +13,12 @@ import {
   getConfigPath,
   configExists,
   validateAgentName,
+  validateMultiaddr,
 } from './config.js';
 
 // 端口验证常量
 const MIN_PORT = 1024;
 const MAX_PORT = 65535;
-
-// Multiaddr 验证正则 (基本格式: /protocol/value/...)
-const MULTIADDR_REGEX = /^\/(ip4|ip6|dns|dns4|dns6)\/[^/]+\/(tcp|udp)\/\d+(\/p2p\/[a-zA-Z0-9]+)?$/;
 
 // 颜色输出
 const colors = {
@@ -293,7 +291,7 @@ export async function initConfig(): Promise<void> {
       const invalidPeers: string[] = [];
       
       for (const peer of peers) {
-        if (MULTIADDR_REGEX.test(peer)) {
+        if (validateMultiaddr(peer).valid) {
           validPeers.push(peer);
         } else {
           invalidPeers.push(peer);


### PR DESCRIPTION
## 修复内容

修复 PR #59 code review 中发现的问题：

### P1 修复
- ✅ 将 import 语句移到文件顶部（TypeScript 最佳实践）
- ✅ 导出 `validateMultiaddr` 和 `validatePath` 供其他模块复用

### P2 修复
- ✅ 修复 `MULTIADDR_REGEX` 在 config.ts 和 init.ts 中不一致的问题
  - config.ts 原来不支持 `dns`，init.ts 不支持 `dnsaddr`
  - 现在统一支持：`ip4|ip6|dns|dns4|dns6|dnsaddr`
- ✅ init.ts 使用从 config.ts 导入的 `validateMultiaddr` 函数

### P3 修复
- ✅ `debugLog` 从 `console.error` 改为 `console.warn`

### 其他改进
- ✅ 在 `validateConfig` 中使用 `validatePath` 函数验证 dataDir（消除未使用的代码警告）

## 测试

```
✓ 43 test files passed
✓ 935 tests passed
```

## 关联

Closes #59 (部分修复)