### PR TITLE
fix: integrate IdentityManager for persistent peer identity

### DIFF
--- a/src/core/f2a.test.ts
+++ b/src/core/f2a.test.ts
@@ -21,7 +21,29 @@ vi.mock('./p2p-network', () => ({
     getDHTPeerCount: vi.fn().mockReturnValue(0),
     isDHTEnabled: vi.fn().mockReturnValue(false),
     on: vi.fn(),
-    getPeerId: vi.fn().mockReturnValue('test-peer-id')
+    getPeerId: vi.fn().mockReturnValue('test-peer-id'),
+    setIdentityManager: vi.fn()
+  }))
+}));
+
+// Mock IdentityManager
+vi.mock('./identity/index.js', () => ({
+  IdentityManager: vi.fn().mockImplementation(() => ({
+    loadOrCreate: vi.fn().mockResolvedValue({ 
+      success: true, 
+      data: { 
+        peerId: 'test-peer-id',
+        privateKey: 'dGVzdC1wcml2YXRlLWtleQ==',
+        e2eeKeyPair: { 
+          publicKey: 'dGVzdC1wdWJsaWM=', 
+          privateKey: 'dGVzdC1wcml2YXRl' 
+        },
+        createdAt: new Date()
+      }
+    }),
+    getPeerIdString: vi.fn().mockReturnValue('test-peer-id'),
+    getPrivateKey: vi.fn().mockReturnValue({ bytes: new Uint8Array(32) }),
+    isLoaded: vi.fn().mockReturnValue(true)
   }))
 }));
 

--- a/src/core/f2a.ts
+++ b/src/core/f2a.ts
@@ -10,6 +10,7 @@ import { homedir } from 'os';
 import { fileURLToPath } from 'url';
 import { readFileSync } from 'fs';
 import { P2PNetwork } from './p2p-network.js';
+import { IdentityManager } from './identity/index.js';
 import { Logger } from '../utils/logger.js';
 import { Middleware } from '../utils/middleware.js';
 import { validateAgentCapability, validateTaskDelegateOptions } from '../utils/validation.js';
@@ -87,16 +88,19 @@ export class F2A extends EventEmitter<F2AEvents> implements F2AInstance {
   private running: boolean = false;
   private registeredCapabilities: Map<string, RegisteredCapability> = new Map();
   private logger: Logger;
+  private identityManager?: IdentityManager;
 
   private constructor(
     agentInfo: AgentInfo,
     p2pNetwork: P2PNetwork,
-    options: Required<F2AOptions>
+    options: Required<F2AOptions>,
+    identityManager?: IdentityManager
   ) {
     super();
     this._agentInfo = agentInfo;
     this.p2pNetwork = p2pNetwork;
     this.options = options;
+    this.identityManager = identityManager;
     
     // 初始化 logger，默认启用文件日志到 dataDir
     const dataDir = options.dataDir || join(homedir(), '.f2a');
@@ -159,11 +163,23 @@ export class F2A extends EventEmitter<F2AEvents> implements F2AInstance {
       multiaddrs: []
     };
 
+    // 创建 IdentityManager 并加载身份
+    const dataDir = mergedOptions.dataDir;
+    const identityManager = new IdentityManager({ dataDir });
+    const identityResult = await identityManager.loadOrCreate();
+    
+    if (!identityResult.success) {
+      throw new Error(`Failed to load or create identity: ${JSON.stringify(identityResult.error)}`);
+    }
+
     // 创建 P2P 网络
     const p2pNetwork = new P2PNetwork(agentInfo, mergedOptions.network);
+    
+    // 注入 IdentityManager（使用持久化的私钥）
+    p2pNetwork.setIdentityManager(identityManager);
 
     // 创建实例
-    const f2a = new F2A(agentInfo, p2pNetwork, mergedOptions);
+    const f2a = new F2A(agentInfo, p2pNetwork, mergedOptions, identityManager);
 
     return f2a;
   }

--- a/src/core/p2p-network.ts
+++ b/src/core/p2p-network.ts
@@ -289,8 +289,10 @@ export class P2PNetwork extends EventEmitter<P2PNetworkEvents> {
       // 如果提供了 IdentityManager，使用持久化的私钥
       if (this.identityManager?.isLoaded()) {
         const privateKey = this.identityManager.getPrivateKey();
-        if (privateKey) {
+        const peerId = this.identityManager.getPeerId();
+        if (privateKey && peerId) {
           libp2pOptions.privateKey = privateKey;
+          libp2pOptions.peerId = peerId;
           this.logger.info('Using persisted identity', {
             peerId: this.identityManager.getPeerIdString()?.slice(0, 16)
           });


### PR DESCRIPTION
## Summary

- F2A.create() now creates and uses IdentityManager
- P2PNetwork.start() passes both `privateKey` and `peerId` to libp2p
- Fixes issue where PeerId changed on every restart

## Problem

Before this fix, every time F2A daemon restarted, a new PeerId was generated. This made it impossible for nodes to maintain stable identities in a P2P network.

## Solution

Integrate the existing `IdentityManager` (which was already implemented but not used) into F2A:

1. F2A.create() creates IdentityManager with the dataDir
2. Calls loadOrCreate() to load existing or create new identity
3. Passes IdentityManager to P2PNetwork
4. P2PNetwork.start() uses the persisted privateKey and peerId

## Testing

```
✅ First start PeerId: 12D3KooWHMo7AFmPahTW
✅ Second start PeerId: 12D3KooWHMo7AFmPahTW (same!)
✅ SUCCESS: PeerId persisted across restarts!
```

## Files Changed

- `src/core/f2a.ts` - Integrate IdentityManager in create()
- `src/core/p2p-network.ts` - Pass both privateKey and peerId to libp2p
- `src/core/f2a.test.ts` - Mock IdentityManager for unit tests