### PR TITLE
fix(validation): add MESSAGE and SKILL_* types to F2AMessageTypeSchema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@f2a/network",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@f2a/network",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f2a/network",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Friend-to-Agent P2P networking protocol for OpenClaw Agents",
   "type": "module",
   "main": "dist/index.js",

--- a/src/core/p2p-network.ts
+++ b/src/core/p2p-network.ts
@@ -655,7 +655,7 @@ export class P2PNetwork extends EventEmitter<P2PNetworkEvents> {
     content: string,
     metadata?: Record<string, unknown>
   ): Promise<Result<void>> {
-    this.logger.info('sendFreeMessage called', {
+    this.logger.debug('sendFreeMessage called', {
       peerId: peerId.slice(0, 16),
       contentLength: content.length
     });
@@ -675,7 +675,7 @@ export class P2PNetwork extends EventEmitter<P2PNetworkEvents> {
     // 发送消息（启用 E2EE 加密）
     const result = await this.sendMessage(peerId, message, true);
     
-    this.logger.info('sendFreeMessage result', {
+    this.logger.debug('sendFreeMessage result', {
       success: result.success,
       error: result.success ? undefined : result.error
     });

--- a/src/core/p2p-network.ts
+++ b/src/core/p2p-network.ts
@@ -655,6 +655,11 @@ export class P2PNetwork extends EventEmitter<P2PNetworkEvents> {
     content: string,
     metadata?: Record<string, unknown>
   ): Promise<Result<void>> {
+    this.logger.info('sendFreeMessage called', {
+      peerId: peerId.slice(0, 16),
+      contentLength: content.length
+    });
+
     const message: F2AMessage = {
       id: randomUUID(),
       type: 'MESSAGE',
@@ -668,7 +673,14 @@ export class P2PNetwork extends EventEmitter<P2PNetworkEvents> {
     };
 
     // 发送消息（启用 E2EE 加密）
-    return this.sendMessage(peerId, message, true);
+    const result = await this.sendMessage(peerId, message, true);
+    
+    this.logger.info('sendFreeMessage result', {
+      success: result.success,
+      error: result.success ? undefined : result.error
+    });
+    
+    return result;
   }
 
   /**

--- a/src/daemon/control-server.ts
+++ b/src/daemon/control-server.ts
@@ -490,10 +490,22 @@ export class ControlServer {
         return;
       }
 
+      this.logger.info('Sending message', { 
+        peerId: command.peerId.slice(0, 16), 
+        contentLength: command.content.length 
+      });
+
       const result = await this.f2a.sendMessage(command.peerId, command.content, command.metadata);
+      
+      this.logger.info('Message send result', { 
+        success: result.success, 
+        error: result.success ? undefined : result.error 
+      });
+
       res.writeHead(200);
       res.end(JSON.stringify(result));
     } catch (error) {
+      this.logger.error('Message send failed', { error: error instanceof Error ? error.message : String(error) });
       res.writeHead(500);
       res.end(JSON.stringify({
         success: false,

--- a/src/daemon/control-server.ts
+++ b/src/daemon/control-server.ts
@@ -490,14 +490,14 @@ export class ControlServer {
         return;
       }
 
-      this.logger.info('Sending message', { 
+      this.logger.debug('Sending message', { 
         peerId: command.peerId.slice(0, 16), 
         contentLength: command.content.length 
       });
 
       const result = await this.f2a.sendMessage(command.peerId, command.content, command.metadata);
       
-      this.logger.info('Message send result', { 
+      this.logger.debug('Message send result', { 
         success: result.success, 
         error: result.success ? undefined : result.error 
       });

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -86,6 +86,7 @@ export const TaskDelegateOptionsSchema = z.object({
 // ============================================================================
 
 // P2-3 修复：添加 DECRYPT_FAILED 消息类型
+// P3-3 修复：添加 MESSAGE 和 SKILL_* 类型的 JSDoc 注释
 export const F2AMessageTypeSchema = z.enum([
   'DISCOVER',
   'DISCOVER_RESP',
@@ -97,12 +98,19 @@ export const F2AMessageTypeSchema = z.enum([
   'DECRYPT_FAILED',
   'PING',
   'PONG',
+  /** 技能公告：Agent 向网络广播自己提供的技能 */
   'SKILL_ANNOUNCE',
+  /** 技能查询：查询网络中具备特定技能的 Agent */
   'SKILL_QUERY',
+  /** 技能查询响应：响应技能查询请求 */
   'SKILL_QUERY_RESPONSE',
+  /** 技能调用：请求 Agent 执行特定技能 */
   'SKILL_INVOKE',
+  /** 技能调用响应：响应技能调用请求 */
   'SKILL_INVOKE_RESPONSE',
+  /** 技能执行结果：返回技能执行的最终结果 */
   'SKILL_RESULT',
+  /** 自由消息：Agent 之间的自然语言通信，无需预定义协议 */
   'MESSAGE'
 ]);
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -96,7 +96,14 @@ export const F2AMessageTypeSchema = z.enum([
   'TASK_DELEGATE',
   'DECRYPT_FAILED',
   'PING',
-  'PONG'
+  'PONG',
+  'SKILL_ANNOUNCE',
+  'SKILL_QUERY',
+  'SKILL_QUERY_RESPONSE',
+  'SKILL_INVOKE',
+  'SKILL_INVOKE_RESPONSE',
+  'SKILL_RESULT',
+  'MESSAGE'
 ]);
 
 export const F2AMessageSchema = z.object({


### PR DESCRIPTION
## 问题描述

`F2AMessageTypeSchema` 缺少 `MESSAGE` 和 `SKILL_*` 类型，导致接收这些消息时验证失败。

## 修复内容

- 添加 `MESSAGE` 类型（Agent 自由消息协议）
- 添加 `SKILL_*` 类型（技能交换协议）
- 添加调试日志便于问题追踪

## 测试

- TypeScript 编译通过
- 742 测试通过

## 发现方式

iterative-code-review 技能自动发现