### PR TITLE
fix: 修复 PeerID 正则表达式 (Issue #101 P2-1)

### DIFF
--- a/packages/openclaw-f2a/src/contact-manager.ts
+++ b/packages/openclaw-f2a/src/contact-manager.ts
@@ -54,8 +54,8 @@ const MAX_CONTACTS = 10000;
 /** P1-4 修复：导入数据最大大小（字节） */
 const MAX_IMPORT_SIZE = 10 * 1024 * 1024; // 10MB
 
-/** P2-1 修复：PeerID 格式正则（libp2p 格式：12D3KooW...） */
-const PEER_ID_REGEX = /^12D3KooW[A-Za-z0-9]{44}$/;
+/** P2-1 修复：PeerID 格式正则（libp2p 格式：12D3KooW...，base58btc 不含 0） */
+const PEER_ID_REGEX = /^12D3KooW[A-Za-z1-9]{44}$/;
 
 /** P2-1 修复：名称最大长度 */
 const MAX_NAME_LENGTH = 100;

--- a/packages/openclaw-f2a/src/handshake-protocol.ts
+++ b/packages/openclaw-f2a/src/handshake-protocol.ts
@@ -122,8 +122,8 @@ export class HandshakeProtocol {
   /** P1-4 修复：shutdown 标志，阻止新请求 */
   private _isShutdown: boolean = false;
   
-  /** P1 修复：PeerID 格式正则（libp2p 格式：12D3KooW...） */
-  private static readonly PEER_ID_REGEX = /^12D3KooW[A-Za-z0-9]{44}$/;
+  /** P1 修复：PeerID 格式正则（libp2p 格式：12D3KooW...，base58btc 不含 0） */
+  private static readonly PEER_ID_REGEX = /^12D3KooW[A-Za-z1-9]{44}$/;
 
   constructor(
     f2a: F2A,


### PR DESCRIPTION
## 问题

Issue #101 P2-1

**PeerID 正则表达式不一致**：
- `contact-manager.ts` 和 `handshake-protocol.ts` 使用 `[A-Za-z0-9]`
- 正确应该是 `[A-Za-z1-9]`（base58btc 不含 `0`）

## 修复

将两个文件中的正则表达式统一改为正确的 base58btc 格式：

```typescript
// 修改前（错误）
const PEER_ID_REGEX = /^12D3KooW[A-Za-z0-9]{44}$/;

// 修改后（正确）
const PEER_ID_REGEX = /^12D3KooW[A-Za-z1-9]{44}$/;
```

## 影响

- **低** - 不影响功能正确性，只接受了一些非标准格式
- 所有 1021 个测试通过 ✅

## 关联

- Closes #101 (P2-1)