### PR TITLE
fix(ci): 修复 integration tests 缺失 test:docker 脚本

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Export logs on failure
         if: failure() && github.event_name == 'push'
-        run: docker compose -f tests/docker/docker-compose.test.yml logs > test-logs.txt
+        run: docker compose -f packages/core/tests/docker/docker-compose.test.yml logs > test-logs.txt
 
       - name: Upload logs on failure
         if: failure() && github.event_name == 'push'

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "test:coverage": "npm run test:coverage --workspaces",
     "test:integration": "npm run test:integration --workspaces",
     "test:e2e": "npm run test:e2e -w @f2a/network",
+    "test:docker": "npm run test:docker -w @f2a/network",
+    "test:docker:10": "npm run test:docker:10 -w @f2a/network",
     "test:all": "npm run test:all --workspaces",
     "test:ci": "npm run test:ci --workspaces"
   },


### PR DESCRIPTION
## 问题

CI #337 的 integration-tests 失败：
```
npm error Missing script: "test:docker"
```

## 根因

1. **根 package.json 缺少 test:docker 脚本** - packages/core 有这个脚本，但根目录没有
2. **CI 中 docker-compose 文件路径错误** - 使用了 `tests/docker/docker-compose.test.yml`，实际路径是 `packages/core/tests/docker/docker-compose.test.yml`

## 修复

- 在根 package.json 添加 `test:docker` 和 `test:docker:10` 脚本
- 修正 ci.yml 中的 docker-compose 文件路径

## 测试

- [x] 本地验证 package.json 语法正确
- [ ] CI 通过