### PR TITLE
fix(docker): 修复 better-sqlite3 原生模块编译问题

### DIFF
--- a/packages/core/tests/docker/Dockerfile.node
+++ b/packages/core/tests/docker/Dockerfile.node
@@ -3,13 +3,17 @@
 
 FROM node:22-alpine
 
+# 安装 better-sqlite3 所需的构建工具
+RUN apk add --no-cache python3 make g++
+
 WORKDIR /app
 
 # 复制所有文件（包括 tsconfig.json）
 COPY . .
 
 # 安装所有依赖（libp2p 是 ESM 模块，需要完整依赖）
-RUN npm install --ignore-scripts
+# 不使用 --ignore-scripts，因为 better-sqlite3 需要编译原生模块
+RUN npm install
 
 # 环境变量
 ENV NODE_ENV=production

--- a/packages/core/tests/docker/Dockerfile.runner
+++ b/packages/core/tests/docker/Dockerfile.runner
@@ -3,13 +3,17 @@
 
 FROM node:22-alpine
 
+# 安装 better-sqlite3 所需的构建工具
+RUN apk add --no-cache python3 make g++
+
 WORKDIR /app
 
 # 先复制所有文件（包括 tsconfig.json）
 COPY . .
 
-# 安装所有依赖（包括 devDependencies），忽略 prepare 脚本
-RUN npm install --ignore-scripts
+# 安装所有依赖（包括 devDependencies）
+# 不使用 --ignore-scripts，因为 better-sqlite3 需要编译原生模块
+RUN npm install
 
 # 构建项目
 RUN npm run build


### PR DESCRIPTION
## 问题

Docker 集成测试失败：
```
error TS2307: Cannot find module 'better-sqlite3' or its corresponding type declarations.
```

## 根因

1. `better-sqlite3` 是原生模块，需要编译
2. Dockerfile 使用了 `--ignore-scripts`，跳过了原生模块编译
3. Alpine Linux 缺少编译工具 (python3, make, g++)

## 修复

- 在两个 Dockerfile 中添加构建工具
- 移除 `--ignore-scripts`，让原生模块正常编译

## 测试

- [ ] CI integration-tests 通过