### PR TITLE
fix(docker): 修复 monorepo 结构下的 Docker 构建

### DIFF
--- a/packages/core/tests/docker/Dockerfile.node
+++ b/packages/core/tests/docker/Dockerfile.node
@@ -8,12 +8,14 @@ RUN apk add --no-cache python3 make g++
 
 WORKDIR /app
 
-# 复制所有文件（包括 tsconfig.json）
+# 复制整个 monorepo
 COPY . .
 
-# 安装所有依赖（libp2p 是 ESM 模块，需要完整依赖）
-# 不使用 --ignore-scripts，因为 better-sqlite3 需要编译原生模块
+# 在根目录安装所有 workspace 依赖
 RUN npm install
+
+# 构建 packages/core
+RUN npm run build -w @f2a/network
 
 # 环境变量
 ENV NODE_ENV=production
@@ -24,4 +26,4 @@ HEALTHCHECK --interval=5s --timeout=3s --retries=10 \
   CMD wget -q --spider http://localhost:9001/health || exit 1
 
 # 启动命令
-CMD ["node", "dist/daemon/main.js"]
+CMD ["node", "packages/core/dist/daemon/main.js"]

--- a/packages/core/tests/docker/Dockerfile.runner
+++ b/packages/core/tests/docker/Dockerfile.runner
@@ -8,15 +8,14 @@ RUN apk add --no-cache python3 make g++
 
 WORKDIR /app
 
-# 先复制所有文件（包括 tsconfig.json）
+# 复制整个 monorepo
 COPY . .
 
-# 安装所有依赖（包括 devDependencies）
-# 不使用 --ignore-scripts，因为 better-sqlite3 需要编译原生模块
+# 在根目录安装所有 workspace 依赖
 RUN npm install
 
-# 构建项目
-RUN npm run build
+# 构建 packages/core
+RUN npm run build -w @f2a/network
 
 # 运行集成测试
 CMD ["npm", "run", "test:integration"]


### PR DESCRIPTION
## 问题

Docker 构建失败：
```
error TS2307: Cannot find module 'better-sqlite3'
```

## 根因

1. `docker-compose.test.yml` 的 context 是 monorepo 根目录 (`../..`)
2. 之前的 Dockerfile 假设 context 是 `packages/core` 目录
3. `npm install` 在根目录运行，但没有正确构建 workspace

## 修复

- 在根目录运行 `npm install` 安装所有 workspace 依赖
- 使用 `npm run build -w @f2a/network` 构建指定包
- 修正 daemon 启动路径为 `packages/core/dist/daemon/main.js`

## 测试

- [ ] CI docker-tests 通过