### PR TITLE
fix(docker): 使用 --workspaces 安装依赖

### DIFF
--- a/packages/core/tests/docker/Dockerfile.node
+++ b/packages/core/tests/docker/Dockerfile.node
@@ -11,11 +11,11 @@ WORKDIR /app
 # 复制整个 monorepo
 COPY . .
 
-# 在根目录安装所有 workspace 依赖
-RUN npm install
+# 安装所有 workspace 依赖
+RUN npm install --workspaces
 
-# 构建 packages/core
-RUN npm run build -w @f2a/network
+# 构建 packages/core（直接进入目录构建）
+RUN cd packages/core && npm run build
 
 # 环境变量
 ENV NODE_ENV=production

--- a/packages/core/tests/docker/Dockerfile.runner
+++ b/packages/core/tests/docker/Dockerfile.runner
@@ -11,11 +11,11 @@ WORKDIR /app
 # 复制整个 monorepo
 COPY . .
 
-# 在根目录安装所有 workspace 依赖
-RUN npm install
+# 安装所有 workspace 依赖
+RUN npm install --workspaces
 
-# 构建 packages/core
-RUN npm run build -w @f2a/network
+# 构建 packages/core（直接进入目录构建）
+RUN cd packages/core && npm run build
 
 # 运行集成测试
 CMD ["npm", "run", "test:integration"]


### PR DESCRIPTION
## 问题

Docker 构建失败：
```
npm error No workspaces found:
npm error   --workspace=@f2a/network
```

## 根因

`npm run build -w @f2a/network` 在容器内无法识别 workspace

## 修复

- 使用 `npm install --workspaces` 安装所有 workspace 依赖
- 直接进入 `packages/core` 目录执行 `npm run build`
- 避免复杂的 workspace 命令识别问题

## 测试

- [ ] CI docker-tests 通过