### PR TITLE
fix(test): 增加 multi-node 测试超时时间

### DIFF
--- a/packages/core/tests/e2e/scenarios/multi-node.test.ts
+++ b/packages/core/tests/e2e/scenarios/multi-node.test.ts
@@ -77,11 +77,13 @@ describe('E2E: Multi-Node Network', () => {
     }, 70000);
 
     it('should have correct peer count for each node', async () => {
+      // CI 环境网络较慢，增加等待时间
+      await new Promise(resolve => setTimeout(resolve, 5000));
       for (let i = 0; i < nodes.length; i++) {
         const peers = await spawner.getConnectedPeers(testConfig.nodes[i].name);
         expect(peers.length).toBeGreaterThanOrEqual(4);
       }
-    }, 15000);
+    }, 30000);
   });
 
   describe('广播消息', () => {
@@ -99,10 +101,10 @@ describe('E2E: Multi-Node Network', () => {
         });
       }
 
-      // 等待所有接收者收到消息
+      // 等待所有接收者收到消息（CI 环境增加超时）
       for (const receiver of receivers) {
         const received = await receiver.messageWaiter.waitForMessage(broadcastMessage, {
-          timeout: testConfig.messageTimeout,
+          timeout: testConfig.messageTimeout * 2,
           fromPeerId: sender.peerId!
         });
         
@@ -110,7 +112,7 @@ describe('E2E: Multi-Node Network', () => {
         expect(received!.content).toBe(broadcastMessage);
         expect(received!.from).toBe(sender.peerId);
       }
-    }, 25000);
+    }, 40000);
 
     it('should handle broadcast from each node', async () => {
       // 每个节点都广播一条消息


### PR DESCRIPTION
## 问题

CI integration-tests 失败：
```
expected 3 to be greater than or equal to 4
Cannot read properties of null (reading 'content')
```

## 根因

CI 环境网络较慢，5 个节点的 mDNS 发现和 P2P 连接需要更多时间。

## 修复

| 测试 | 修改前 | 修改后 |
|------|--------|--------|
| `should have correct peer count` | 15s | 30s + 5s 等待 |
| `should broadcast message` | 25s | 40s |
| messageTimeout 系数 | 1x | 2x |

## 测试

- [ ] CI integration-tests 通过