### PR TITLE
fix(docker): 使用 npm install 替代 --workspaces 标志

### DIFF
--- a/packages/core/tests/docker/Dockerfile.node
+++ b/packages/core/tests/docker/Dockerfile.node
@@ -11,8 +11,8 @@ WORKDIR /app
 # 复制整个 monorepo
 COPY . .
 
-# 安装所有 workspace 依赖
-RUN npm install --workspaces
+# 安装所有依赖（npm 会自动识别 workspaces）
+RUN npm install
 
 # 构建 packages/core（直接进入目录构建）
 RUN cd packages/core && npm run build

--- a/packages/core/tests/docker/Dockerfile.runner
+++ b/packages/core/tests/docker/Dockerfile.runner
@@ -11,8 +11,8 @@ WORKDIR /app
 # 复制整个 monorepo
 COPY . .
 
-# 安装所有 workspace 依赖
-RUN npm install --workspaces
+# 安装所有依赖（npm 会自动识别 workspaces）
+RUN npm install
 
 # 构建 packages/core（直接进入目录构建）
 RUN cd packages/core && npm run build


### PR DESCRIPTION
## 问题

Docker 构建失败：
```
npm error No workspaces found!
```

## 根因

`npm install --workspaces` 在 Docker 构建时报错，但 `npm install` 可以正常工作。npm 会自动检测 package.json 中的 workspaces 配置。

## 修复

| 修改前 | 修改后 |
|--------|--------|
| `npm install --workspaces` | `npm install` |

## 测试

- [ ] CI docker-tests 通过