### PR TITLE
fix(docker): 使用 WORKDIR 替代 cd 命令，显式复制 packages 目录

### DIFF
--- a/packages/core/tests/docker/Dockerfile.node
+++ b/packages/core/tests/docker/Dockerfile.node
@@ -8,14 +8,24 @@ RUN apk add --no-cache python3 make g++
 
 WORKDIR /app
 
-# 复制整个 monorepo
-COPY . .
+# 先复制 package.json 文件以利用 Docker 缓存
+COPY package*.json ./
+COPY packages/core/package*.json ./packages/core/
+COPY packages/openclaw-f2a/package*.json ./packages/openclaw-f2a/ 2>/dev/null || true
 
-# 安装所有依赖（npm 会自动识别 workspaces）
+# 复制源代码
+COPY packages/core ./packages/core
+COPY packages/openclaw-f2a ./packages/openclaw-f2a 2>/dev/null || true
+
+# 安装所有依赖
 RUN npm install
 
-# 构建 packages/core（直接进入目录构建）
-RUN cd packages/core && npm run build
+# 切换到 packages/core 目录并构建
+WORKDIR /app/packages/core
+RUN npm run build
+
+# 切换回主目录
+WORKDIR /app
 
 # 环境变量
 ENV NODE_ENV=production

--- a/packages/core/tests/docker/Dockerfile.runner
+++ b/packages/core/tests/docker/Dockerfile.runner
@@ -8,14 +8,22 @@ RUN apk add --no-cache python3 make g++
 
 WORKDIR /app
 
-# 复制整个 monorepo
-COPY . .
+# 先复制 package.json 文件
+COPY package*.json ./
+COPY packages/core/package*.json ./packages/core/
 
-# 安装所有依赖（npm 会自动识别 workspaces）
+# 复制源代码
+COPY packages/core ./packages/core
+
+# 安装所有依赖
 RUN npm install
 
-# 构建 packages/core（直接进入目录构建）
-RUN cd packages/core && npm run build
+# 切换到 packages/core 目录并构建
+WORKDIR /app/packages/core
+RUN npm run build
+
+# 切换回主目录
+WORKDIR /app
 
 # 运行集成测试
 CMD ["npm", "run", "test:integration"]


### PR DESCRIPTION
## 问题

Docker 构建失败：
```
/bin/sh: cd: line 0: can't cd to packages/core: No such file or directory
```

## 根因

1. `RUN cd packages/core && npm run build` 在 Docker 构建时失败
2. `COPY . .` 可能没有正确复制 packages 目录（可能是 Docker 缓存或 context 问题）

## 修复

1. 使用 `WORKDIR` 切换工作目录，避免 shell cd 问题
2. 显式 `COPY packages/core ./packages/core` 确保源代码存在
3. 使用 Docker 缓存优化 package.json 复制

## 测试

- [ ] CI docker-tests 通过