### PR TITLE
fix(docker): 修正 docker-compose context 指向 monorepo 根目录

### DIFF
--- a/packages/core/tests/docker/Dockerfile.node
+++ b/packages/core/tests/docker/Dockerfile.node
@@ -11,11 +11,9 @@ WORKDIR /app
 # 先复制 package.json 文件以利用 Docker 缓存
 COPY package*.json ./
 COPY packages/core/package*.json ./packages/core/
-COPY packages/openclaw-f2a/package*.json ./packages/openclaw-f2a/ 2>/dev/null || true
 
 # 复制源代码
 COPY packages/core ./packages/core
-COPY packages/openclaw-f2a ./packages/openclaw-f2a 2>/dev/null || true
 
 # 安装所有依赖
 RUN npm install

--- a/packages/core/tests/docker/docker-compose.test.yml
+++ b/packages/core/tests/docker/docker-compose.test.yml
@@ -7,8 +7,8 @@ services:
   # 引导节点（稳定，其他节点连接它）
   bootstrap:
     build:
-      context: ../..
-      dockerfile: tests/docker/Dockerfile.node
+      context: ../../..
+      dockerfile: packages/core/tests/docker/Dockerfile.node
     networks:
       f2a-test-net:
         aliases:
@@ -28,8 +28,8 @@ services:
   # 动态生成的节点（使用 --scale 参数调整数量）
   node:
     build:
-      context: ../..
-      dockerfile: tests/docker/Dockerfile.node
+      context: ../../..
+      dockerfile: packages/core/tests/docker/Dockerfile.node
     networks:
       - f2a-test-net
     environment:
@@ -51,8 +51,8 @@ services:
   # 测试运行器
   test-runner:
     build:
-      context: ../..
-      dockerfile: tests/docker/Dockerfile.runner
+      context: ../../..
+      dockerfile: packages/core/tests/docker/Dockerfile.runner
     networks:
       - f2a-test-net
     environment:
@@ -66,7 +66,7 @@ services:
       node:
         condition: service_healthy
     volumes:
-      - ../../coverage:/app/coverage  # 导出覆盖率报告
+      - ../../../coverage:/app/coverage  # 导出覆盖率报告
 
 networks:
   f2a-test-net:


### PR DESCRIPTION
## 问题

Docker 构建失败：
```
failed to calculate checksum: "/packages/core": not found
```

## 根因

docker-compose context `../..` 从 `packages/core/tests/docker/` 解析为 `packages/core/`，不是 monorepo 根目录。

所以 `COPY packages/core ./packages/core` 在 `packages/core/` context 中找不到目标。

## 修复

| 文件 | 修改前 | 修改后 |
|------|--------|--------|
| docker-compose.test.yml | context: `../..` | context: `../../..` |
| dockerfile 路径 | `tests/docker/Dockerfile.*` | `packages/core/tests/docker/Dockerfile.*` |
| volumes 路径 | `../../coverage` | `../../../coverage` |

## 测试

- [ ] CI docker-tests 通过