### PR TITLE
fix(docker): 正确设置 docker-compose context 到 monorepo 根目录

### DIFF
--- a/packages/core/tests/docker/docker-compose.test.yml
+++ b/packages/core/tests/docker/docker-compose.test.yml
@@ -7,8 +7,8 @@ services:
   # 引导节点（稳定，其他节点连接它）
   bootstrap:
     build:
-      context: ../..
-      dockerfile: tests/docker/Dockerfile.node
+      context: ../../../..
+      dockerfile: packages/core/tests/docker/Dockerfile.node
     networks:
       f2a-test-net:
         aliases:
@@ -28,8 +28,8 @@ services:
   # 动态生成的节点（使用 --scale 参数调整数量）
   node:
     build:
-      context: ../..
-      dockerfile: tests/docker/Dockerfile.node
+      context: ../../../..
+      dockerfile: packages/core/tests/docker/Dockerfile.node
     networks:
       - f2a-test-net
     environment:
@@ -51,8 +51,8 @@ services:
   # 测试运行器
   test-runner:
     build:
-      context: ../..
-      dockerfile: tests/docker/Dockerfile.runner
+      context: ../../../..
+      dockerfile: packages/core/tests/docker/Dockerfile.runner
     networks:
       - f2a-test-net
     environment:
@@ -66,7 +66,7 @@ services:
       node:
         condition: service_healthy
     volumes:
-      - ../../coverage:/app/coverage  # 导出覆盖率报告
+      - ../../../../coverage:/app/coverage  # 导出覆盖率报告
 
 networks:
   f2a-test-net:


### PR DESCRIPTION
## 问题

Codex 指出 PR #121 的 context 路径仍然不正确：
- `../../..` 从 `packages/core/tests/docker/` 解析为 `packages/`
- 不是 monorepo 根目录

## 路径分析

从 `packages/core/tests/docker/docker-compose.test.yml`：
- `../..` → `packages/core/`
- `../../..` → `packages/` ❌
- `../../../..` → monorepo 根目录 ✅

## 修复

| 修改前 | 修改后 |
|--------|--------|
| context: `../../..` | context: `../../../..` |
| volumes: `../../../coverage` | volumes: `../../../../coverage` |

## 测试

- [ ] CI docker-tests 通过

Co-authored-by: Codex <codex@openai.com>