### PR TITLE
fix(docker): 移除 Dockerfile 中无效的 shell 重定向语法

### DIFF
--- a/packages/core/tests/docker/Dockerfile.node
+++ b/packages/core/tests/docker/Dockerfile.node
@@ -11,11 +11,9 @@ WORKDIR /app
 # 先复制 package.json 文件以利用 Docker 缓存
 COPY package*.json ./
 COPY packages/core/package*.json ./packages/core/
-COPY packages/openclaw-f2a/package*.json ./packages/openclaw-f2a/ 2>/dev/null || true
 
 # 复制源代码
 COPY packages/core ./packages/core
-COPY packages/openclaw-f2a ./packages/openclaw-f2a 2>/dev/null || true
 
 # 安装所有依赖
 RUN npm install


### PR DESCRIPTION
## 问题

Docker 构建失败：
```
failed to calculate checksum: "/||": not found
```

## 根因

Dockerfile.node 中使用了 `2>/dev/null || true` 语法：
```dockerfile
COPY packages/openclaw-f2a/package*.json ./packages/openclaw-f2a/ 2>/dev/null || true
```

**Docker COPY 命令不支持 shell 重定向**，这导致构建失败。

## 修复

删除无效的 COPY 命令：
- `COPY packages/openclaw-f2a/package*.json ...`
- `COPY packages/openclaw-f2a ./packages/openclaw-f2a ...`

`packages/openclaw-f2a` 目录在构建 context 中可能不存在，这些 COPY 是可选的，直接移除。

## 测试

- [ ] CI docker-tests 通过