### PR TITLE
fix(deps): 添加 better-sqlite3 到 packages/core 依赖

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,12 +59,14 @@
     "@libp2p/tcp": "^11.0.13",
     "@multiformats/multiaddr": "^13.0.1",
     "@noble/curves": "^2.0.1",
+    "better-sqlite3": "^11.0.0",
     "eventemitter3": "^5.0.0",
     "libp2p": "^3.1.6",
     "uint8arrays": "^5.0.0",
     "zod": "^3.22.0"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20.0.0",
     "@vitest/coverage-v8": "^1.6.1",
     "err-code": "^3.0.1",


### PR DESCRIPTION
## 问题

Docker 构建失败：
```
Cannot find module 'better-sqlite3' or its corresponding type declarations.
```

## 根因

1. `packages/core/src/core/message-store.ts` 使用了 `better-sqlite3`
2. 但 `better-sqlite3` 依赖在 `packages/openclaw-f2a/package.json` 中
3. Docker 构建只复制 `packages/core`，导致依赖缺失

## 修复

将 `better-sqlite3` 和 `@types/better-sqlite3` 添加到 `packages/core/package.json`

## 测试

- [ ] CI docker-tests 通过