### PR TITLE
fix(auth): CLI message send via challenge-response + daemon token prefix fix

### DIFF
--- a/packages/cli/src/messages.ts
+++ b/packages/cli/src/messages.ts
@@ -4,38 +4,58 @@
  * 
  * Challenge-Response 签名认证
  * - 按 agentId 查找本地身份文件
- * - 签名 Challenge 发送消息
+ * - 通过 /api/v1/challenge 获取 challenge
+ * - 签名后通过 /api/v1/challenge/verify 获取临时 agentToken
+ * - 使用 agentToken 发送消息
  */
 
 import { sendRequest } from './http-client.js';
-import { join } from 'path';
-import { readIdentityByAgentId, AGENT_IDENTITIES_DIR } from './init.js';
+import { readIdentityByAgentId } from './init.js';
 import type { RFC008IdentityFile, Challenge, ChallengeResponse } from '@f2a/network';
 import { signChallenge } from '@f2a/network';
 
 /**
- * Challenge-Response 认证流程
+ * 通过 Challenge-Response 获取临时 Agent Token
+ * 
+ * 流程：
+ * 1. POST /api/v1/challenge 获取 challenge
+ * 2. 用私钥签名 challenge
+ * 3. POST /api/v1/challenge/verify 验证并获取 agentToken
  */
-async function challengeResponseFlow(
+async function getAgentTokenViaChallenge(
   identity: RFC008IdentityFile,
-  initialResult: Record<string, unknown>,
-  messagePayload: Record<string, unknown>
-): Promise<Record<string, unknown>> {
-  const challenge = initialResult.challenge as Challenge | undefined;
-  
-  if (!challenge) {
-    return initialResult;
+  toAgentId?: string
+): Promise<string | undefined> {
+  // 1. 请求 challenge
+  const challengeResult = await sendRequest('POST', '/api/v1/challenge', {
+    agentId: identity.agentId,
+    operation: 'send_message',
+    targetAgentId: toAgentId,
+  });
+
+  if (!challengeResult.success || !challengeResult.challenge) {
+    console.error('❌ 获取 Challenge 失败:', challengeResult.error);
+    return undefined;
   }
 
+  const challenge = challengeResult.challenge as Challenge;
+
+  // 2. 签名 challenge
   const response: ChallengeResponse = signChallenge(challenge, identity.privateKey);
 
-  const finalPayload = {
-    ...messagePayload,
-    challengeResponse: response,
-    publicKey: identity.publicKey,
-  };
+  // 3. 验证 challenge 并获取 token
+  const verifyResult = await sendRequest('POST', '/api/v1/challenge/verify', {
+    agentId: identity.agentId,
+    challenge,
+    response,
+  });
 
-  return sendRequest('POST', '/api/v1/messages', finalPayload);
+  if (!verifyResult.success || !verifyResult.agentToken) {
+    console.error('❌ Challenge 验证失败:', verifyResult.error);
+    return undefined;
+  }
+
+  return verifyResult.agentToken as string;
 }
 
 /**
@@ -73,24 +93,32 @@ export async function sendMessage(options: {
     process.exit(1);
   }
 
-  const messagePayload = {
-    fromAgentId: agentId,
-    toAgentId,
-    content,
-    type: type || 'message',
-    metadata,
-    publicKey: identity.publicKey,
-  };
-
   try {
-    const initialResult = await sendRequest('POST', '/api/v1/messages', messagePayload);
+    // 通过 Challenge-Response 获取临时 Agent Token
+    const agentToken = await getAgentTokenViaChallenge(identity, toAgentId);
 
-    if (initialResult.challenge) {
-      const finalResult = await challengeResponseFlow(identity, initialResult, messagePayload);
-      handleSendResult(finalResult, agentId, toAgentId);
-    } else {
-      handleSendResult(initialResult, agentId, toAgentId);
+    if (!agentToken) {
+      console.error('❌ 无法获取 Agent Token，消息发送失败');
+      console.error('提示: 请确保 Agent 已注册，且 Daemon 正在运行');
+      process.exit(1);
     }
+
+    const messagePayload = {
+      fromAgentId: agentId,
+      toAgentId,
+      content,
+      type: type || 'message',
+      metadata,
+    };
+
+    const result = await sendRequest(
+      'POST',
+      '/api/v1/messages',
+      messagePayload,
+      { Authorization: agentToken }
+    );
+
+    handleSendResult(result, agentId, toAgentId);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error(`❌ 无法连接到 Daemon: ${message}`);

--- a/packages/daemon/src/handlers/message-handler.ts
+++ b/packages/daemon/src/handlers/message-handler.ts
@@ -77,7 +77,7 @@ export class MessageHandler {
           // 从 Authorization header 获取 agent token
           const authHeader = req.headers['authorization'] as string;
           const agentToken = authHeader?.startsWith('agent-')
-            ? authHeader.slice(6)  // 去掉 'agent-' 前缀
+            ? authHeader
             : undefined;
 
           if (!agentToken) {


### PR DESCRIPTION
## 修复内容

### Bug 1: CLI 消息发送认证错误
- 问题: CLI 的  之前不走正规的认证流程，依赖 daemon 返回 challenge 才能继续，但 daemon 的 message handler 已经强制要求 Authorization header，导致消息发送始终报 401
- 修复: 重写 ，正规走 challenge-response 三步流程:
  1.  获取 challenge
  2. 用私钥签名 challenge
  3.  获取临时 agentToken
  4.  带  发消息

### Bug 2: 注册返回的 Agent Token 未保存
- 设计决策: **不修**。agent token 是内存 token，设计上不持久化、不暴露给客户端磁盘。CLI 每次发消息通过 challenge-response 临时获取，用完即弃。

### Bug 3: Daemon Token 验证双重削前缀
- 问题:  生成的 token 带  前缀，但  和  都用  削掉了前缀，导致  永远查不到 token
- 修复: 三处  全部去掉，保留完整的  传给 token manager

## 修改文件
- 
- 
- 