### PR TITLE
Add conversation history for Daemon and P2P inbound messages

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@
 | **协议规格** | [消息协议](protocols/message.md) | 两层协议设计、消息类型定义 |
 | | [mDNS 发现](protocols/mdns.md) | mDNS/DNS-SD 自动发现规格 |
 | **设计参考** | [A2A 借鉴](design/a2a-lessons.md) | Google A2A 协议借鉴思路 |
+| | [Agent Social Roadmap](design/agent-social-roadmap.md) | F2A Social Layer 演进路线 |
 | **RFC** | [RFC 目录](rfcs/) | 规范提案文档 |
 
 ---
@@ -70,7 +71,8 @@ docs/
 │   ├── message.md               # 消息协议
 │   └── mdns.md                  # mDNS 发现协议
 ├── design/                      # 设计参考
-│   └── a2a-lessons.md           # A2A 协议借鉴
+│   ├── a2a-lessons.md           # A2A 协议借鉴
+│   └── agent-social-roadmap.md  # Agent Social Layer 演进路线
 ├── rfcs/                        # RFC 规范文档
 │   ├── 001-reputation-system.md
 │   ├── 002-cli-agent-architecture.md

--- a/docs/design/agent-social-roadmap.md
+++ b/docs/design/agent-social-roadmap.md
@@ -1,0 +1,143 @@
+# F2A Agent Social Roadmap
+
+> 记录 F2A 从 P2P 消息网络演进为 Agent Social Network 的建议路线。
+
+---
+
+## 项目定位
+
+F2A 不只是一个 libp2p 消息 SDK，而是一个 Agent-to-Agent 协作网络底座。
+
+当前已经具备 Node/Agent 身份分离、Daemon、CLI、Webhook、Challenge-Response、Agent 注册和基础消息能力。下一阶段的重点应从"能发送消息"转向"Agent 能可靠、安全、有上下文地完成一次互动"。
+
+核心方向：
+
+- Node 作为长期运行的网络基础设施，负责连接、发现、路由和控制 API。
+- Agent 作为业务身份，持有独立 AgentId、密钥、能力、消息入口和未来的关系/记忆/信誉。
+- Social Layer 以每个 Agent 为中心，逐步建立会话、通讯录、私有印象和协作空间。
+
+---
+
+## 当前关键风险
+
+### 1. RFC008 AgentId 与远程路由仍需统一
+
+当前主线已经采用 `agent:<公钥指纹16位>` 的 RFC008 AgentId，但部分远程路由逻辑仍假设旧格式 `agent:<PeerId前16位>:<随机>`。如果不解决 AgentId 到 Node/Peer 的发现映射，跨节点通信会停留在局域或旧格式兼容状态。
+
+建议优先设计 AgentId -> PeerId/NodeId 的发现索引，可以从本地注册表和 DHT provider record 的最小版本开始。
+
+### 2. OpenClaw 插件需要严格遵守 noReply
+
+RFC013 已把 `noReply` 默认值改为 true，目标是防止 Agent 无限回复循环。插件收到消息时必须检查 `metadata.noReply`，并在 true 时记录/确认但不自动回复。
+
+### 3. Message Queue 不是 Social Layer 的长期存储
+
+内存队列适合投递 fallback，但不适合作为会话历史、搜索、摘要和印象系统的数据源。Social Layer 需要持久化 Message/Conversation 存储。
+
+### 4. 文档状态需要持续收敛
+
+部分 README、RFC 索引和包文档还反映不同阶段的状态。进入 Social Layer 后，建议每个阶段结束时同步 RFC 状态、文档索引和实际 CLI/API 能力。
+
+---
+
+## 路线图
+
+### Phase 0: Foundation Alignment
+
+目标：修正会阻塞 A2A 闭环的基础分歧。
+
+- 统一 RFC008 AgentId 的跨节点寻址模型。
+- 修复 OpenClaw 插件的 `noReply` 接收行为。
+- 清理旧 CLI 命令别名和文档状态。
+- 明确 `mcp-server` 是否进入 npm workspace 和发布流程。
+
+验收标准：
+
+- 新格式 AgentId 可以被发现并路由到所在 Node。
+- Agent 收到 `noReply=true` 消息不会自动发起回复。
+- 文档索引与当前已实现 RFC 状态一致。
+
+### Phase 1: Conversation Layer
+
+目标：让两个 Agent 的多轮消息具备稳定上下文。
+
+- 引入/接入 SQLite 消息历史存储。
+- 增加 `conversationId` 和 `replyToMessageId` 语义。
+- 支持按 Agent、对方 Agent、会话查询消息。
+- CLI 增加会话查看/查询能力。
+- 为未来摘要和印象系统记录结构化事件。
+
+验收标准：
+
+- Daemon 重启后仍能查询历史消息。
+- 一次多轮 A2A 对话可以被关联到同一个 conversation。
+- CLI/API 可以查看 Agent 与指定对方的消息历史。
+
+### Phase 2: Contact Layer
+
+目标：每个 Agent 拥有自己的通讯录。
+
+- 添加/删除/更新联系人。
+- 关系类型：friend、collaborator、service-provider、blocked。
+- 从发现结果保存联系人。
+- 查询联系人最近互动时间和基础能力。
+
+验收标准：
+
+- 每个 Agent 的通讯录隔离存储。
+- Agent 可以基于联系人列表选择常用协作对象。
+
+### Phase 3: Impression Layer
+
+目标：每个 Agent 形成私有、可解释的对其他 Agent 的印象。
+
+- 记录 trust score、能力观察、互动次数、标签和私密笔记。
+- 从消息结果、`noReplyReason`、任务完成状态生成 impression event。
+- 先使用本地规则评分，不引入全网共识。
+
+验收标准：
+
+- 印象数据默认不共享。
+- Agent 可以查询"我对某个 Agent 的印象"。
+- 协作选择可以读取印象数据作为输入。
+
+### Phase 4: Basic Collaboration
+
+目标：从自由聊天进入可追踪的任务协作。
+
+- 任务委托协议：request、accept、progress、result、reject。
+- 支持简单 coordinator 模式。
+- 协作空间记录成员、角色、任务列表和共享上下文。
+- Dashboard 展示协作状态。
+
+验收标准：
+
+- 一个 coordinator Agent 可以把任务拆给多个 Agent。
+- 任务状态和结果可查询、可回放。
+
+### Phase 5: Network Hardening and Public Demo
+
+目标：让 F2A 能被外部用户稳定试用。
+
+- 多节点真实网络测试。
+- NAT、relay、bootstrap 默认配置和部署文档。
+- Docker Compose demo。
+- MCP Server 正式纳入包，让 AI 客户端能自然操作 F2A。
+
+验收标准：
+
+- 新用户可以按文档在两台机器上跑通 A2A 消息。
+- Demo 能展示发现、联系、会话和基础协作闭环。
+
+---
+
+## 近期原则
+
+短期不要急于实现任务市场和经济系统。优先把"两个 Agent 可靠、安全、有上下文地聊完一次事"打磨成标杆闭环。
+
+建议实现顺序：
+
+1. 修正 RFC008 寻址和 noReply 接收行为。
+2. 做 Conversation Layer 的持久化和查询。
+3. 在 Conversation Layer 稳定后再进入通讯录和印象系统。
+

--- a/docs/superpowers/plans/2026-04-25-conversation-layer.md
+++ b/docs/superpowers/plans/2026-04-25-conversation-layer.md
@@ -1,0 +1,563 @@
+# Conversation Layer 实施计划
+
+> **给 Agentic 工作者：** 必需子技能：使用 superpowers:subagent-driven-development（推荐）或当前会话逐任务执行。步骤使用 checkbox（`- [x]`）语法跟踪。
+
+**目标：** 为 F2A Phase 1 增加最小可用 Conversation Layer，让 Daemon API 发送链路和本地投递消息持久化到 SQLite，并通过 API/CLI 查询会话历史。
+
+**架构：** 复用 `@f2a/network` 现有 `MessageStore`，通过幂等迁移扩展会话字段。`ControlServer` 创建并注入 `MessageStore` 到 `MessageHandler`，`MessageHandler` 在发送和查询路径中负责 conversationId 解析、历史写入和历史读取；CLI 增加 conversation/thread 查询命令和 send 参数。第一版覆盖 Daemon API 发送链路和本地投递历史，P2P 远程入站路径后续补齐。
+
+**技术栈：** TypeScript、Node.js ESM、Vitest、better-sqlite3、现有 Daemon HTTP handler/CLI sendRequest 模式。
+
+---
+
+### Task 1: 扩展 MessageStore 会话 schema 和查询能力
+
+**文件：**
+- 修改: `packages/network/src/core/message-store.ts`
+- 测试: `packages/network/src/core/message-store.test.ts`
+
+- [x] **Step 1: 写失败测试 - 新字段写入与按会话查询**
+
+在 `message-store.test.ts` 增加测试：
+
+```ts
+it('应该保存并按 conversationId 查询消息', async () => {
+  await store.add(createMessageRecord(
+    'msg-1',
+    'agent:alice',
+    'agent:bob',
+    'message',
+    Date.now(),
+    'hello',
+    { content: 'hello' },
+    {
+      conversationId: 'conv-1',
+      replyToMessageId: undefined,
+      direction: 'outbound',
+      agentId: 'agent:alice',
+      peerAgentId: 'agent:bob',
+      metadata: { noReply: false }
+    }
+  ));
+
+  const messages = await store.getByConversation('agent:alice', 'conv-1');
+
+  expect(messages).toHaveLength(1);
+  expect(messages[0].conversationId).toBe('conv-1');
+  expect(messages[0].agentId).toBe('agent:alice');
+  expect(messages[0].peerAgentId).toBe('agent:bob');
+});
+```
+
+- [x] **Step 2: 运行测试确认失败**
+
+运行: `npm test -w @f2a/network -- src/core/message-store.test.ts`
+
+预期: FAIL，原因是 `createMessageRecord` 不接受第 8 个参数，`getByConversation` 不存在。
+
+- [x] **Step 3: 写最小实现**
+
+在 `MessageRecord` 增加字段：
+
+```ts
+conversationId?: string;
+replyToMessageId?: string;
+direction?: 'inbound' | 'outbound' | 'local';
+agentId?: string;
+peerAgentId?: string;
+metadata?: string;
+```
+
+在 `initTables()` 中用 `ALTER TABLE ... ADD COLUMN` 包裹 try/catch 或查询 `PRAGMA table_info(messages)` 后补列：
+
+```sql
+conversation_id TEXT
+reply_to_message_id TEXT
+direction TEXT
+agent_id TEXT
+peer_agent_id TEXT
+metadata TEXT
+created_at INTEGER
+```
+
+更新 `add()` 写入新字段，增加：
+
+```ts
+getByConversation(agentId: string, conversationId: string, limit?: number): Promise<MessageRecord[]>
+```
+
+- [x] **Step 4: 运行测试确认通过**
+
+运行: `npm test -w @f2a/network -- src/core/message-store.test.ts`
+
+预期: PASS。
+
+- [x] **Step 5: 写失败测试 - 会话摘要列表**
+
+增加测试：
+
+```ts
+it('应该返回 Agent 的会话摘要列表', async () => {
+  await store.add(createMessageRecord('msg-1', 'agent:alice', 'agent:bob', 'message', 1000, 'first', { content: 'first' }, {
+    conversationId: 'conv-1',
+    direction: 'outbound',
+    agentId: 'agent:alice',
+    peerAgentId: 'agent:bob'
+  }));
+  await store.add(createMessageRecord('msg-2', 'agent:bob', 'agent:alice', 'message', 2000, 'second', { content: 'second' }, {
+    conversationId: 'conv-1',
+    direction: 'inbound',
+    agentId: 'agent:alice',
+    peerAgentId: 'agent:bob'
+  }));
+
+  const conversations = await store.listConversations('agent:alice');
+
+  expect(conversations).toEqual([
+    {
+      conversationId: 'conv-1',
+      peerAgentId: 'agent:bob',
+      lastMessageAt: 2000,
+      messageCount: 2,
+      lastSummary: 'second'
+    }
+  ]);
+});
+```
+
+- [x] **Step 6: 运行测试确认失败**
+
+运行: `npm test -w @f2a/network -- src/core/message-store.test.ts`
+
+预期: FAIL，原因是 `listConversations` 不存在。
+
+- [x] **Step 7: 写最小实现**
+
+新增类型：
+
+```ts
+export interface ConversationSummary {
+  conversationId: string;
+  peerAgentId: string;
+  lastMessageAt: number;
+  messageCount: number;
+  lastSummary?: string;
+}
+```
+
+新增方法：
+
+```ts
+listConversations(agentId: string, limit?: number): Promise<ConversationSummary[]>
+```
+
+SQL 按 `agent_id/conversation_id/peer_agent_id` 聚合，按最新时间倒序。
+
+- [x] **Step 8: 运行测试确认通过**
+
+运行: `npm test -w @f2a/network -- src/core/message-store.test.ts`
+
+预期: PASS。
+
+### Task 2: MessageHandler 接入 MessageStore 并返回 conversationId
+
+**文件：**
+- 修改: `packages/daemon/src/types/handlers.ts`
+- 修改: `packages/daemon/src/handlers/message-handler.ts`
+- 修改: `packages/daemon/src/control-server.ts`
+- 测试: `packages/daemon/src/handlers/message-handler.test.ts`
+
+- [x] **Step 1: 写失败测试 - 发送消息返回 conversationId 并写历史**
+
+在 `message-handler.test.ts` 增加测试，构造带 `add/getByConversation` spy 的 fake messageStore：
+
+```ts
+it('发送消息时应该生成 conversationId 并持久化历史', async () => {
+  const messageStore = {
+    add: vi.fn().mockResolvedValue(undefined),
+    getByConversation: vi.fn(),
+    getByMessageId: vi.fn(),
+    listConversations: vi.fn(),
+    getByAgent: vi.fn(),
+  };
+  const handler = createMessageHandler({ messageStore });
+
+  const { resBody } = await postMessage(handler, {
+    fromAgentId: 'agent:alice',
+    toAgentId: 'agent:bob',
+    content: 'hello'
+  });
+
+  expect(resBody.success).toBe(true);
+  expect(resBody.conversationId).toMatch(/^conv-/);
+  expect(messageStore.add).toHaveBeenCalledWith(expect.objectContaining({
+    conversationId: resBody.conversationId,
+    agentId: 'agent:alice',
+    peerAgentId: 'agent:bob'
+  }));
+});
+```
+
+- [x] **Step 2: 运行测试确认失败**
+
+运行: `npm test -w @f2a/daemon -- src/handlers/message-handler.test.ts`
+
+预期: FAIL，原因是 handler deps 不接受 `messageStore`，响应没有 `conversationId`。
+
+- [x] **Step 3: 写最小实现**
+
+在 `MessageHandlerDeps` 增加：
+
+```ts
+messageStore?: MessageStore;
+```
+
+`ControlServer` 构造：
+
+```ts
+this.messageStore = new MessageStore({
+  dbPath: join(this.dataDir, 'messages.db')
+});
+```
+
+并注入 `MessageHandler`。
+
+`SendMessageBody` 增加：
+
+```ts
+conversationId?: string;
+replyToMessageId?: string;
+```
+
+发送时计算：
+
+```ts
+const conversationId = data.conversationId ?? `conv-${randomUUID()}`;
+```
+
+持久化 `createMessageRecord(...)`，响应包含 `conversationId` 和 `historyPersisted`。
+
+- [x] **Step 4: 运行测试确认通过**
+
+运行: `npm test -w @f2a/daemon -- src/handlers/message-handler.test.ts`
+
+预期: PASS。
+
+- [x] **Step 5: 写失败测试 - replyTo 沿用原 conversation**
+
+增加测试：
+
+```ts
+it('replyToMessageId 命中历史时应该沿用原 conversationId', async () => {
+  const messageStore = {
+    add: vi.fn().mockResolvedValue(undefined),
+    getByMessageId: vi.fn().mockResolvedValue({
+      id: 'msg-original',
+      conversationId: 'conv-existing'
+    }),
+    listConversations: vi.fn(),
+    getByConversation: vi.fn(),
+    getByAgent: vi.fn(),
+  };
+  const handler = createMessageHandler({ messageStore });
+
+  const { resBody } = await postMessage(handler, {
+    fromAgentId: 'agent:bob',
+    toAgentId: 'agent:alice',
+    content: 'reply',
+    replyToMessageId: 'msg-original'
+  });
+
+  expect(resBody.conversationId).toBe('conv-existing');
+});
+```
+
+- [x] **Step 6: 运行测试确认失败**
+
+运行: `npm test -w @f2a/daemon -- src/handlers/message-handler.test.ts`
+
+预期: FAIL，原因是 `replyToMessageId` 未查询历史。
+
+- [x] **Step 7: 写最小实现**
+
+在 `MessageStore` 增加并导出：
+
+```ts
+getByMessageId(messageId: string): Promise<MessageRecord | undefined>
+```
+
+`MessageHandler` 中按优先级解析 conversation：
+
+1. `data.conversationId`
+2. `data.replyToMessageId` 命中历史的 `conversationId`
+3. 新建 `conv-${randomUUID()}`
+
+- [x] **Step 8: 运行测试确认通过**
+
+运行:
+
+```bash
+npm test -w @f2a/network -- src/core/message-store.test.ts
+npm test -w @f2a/daemon -- src/handlers/message-handler.test.ts
+```
+
+预期: PASS。
+
+### Task 3: 增加历史查询 API
+
+**文件：**
+- 修改: `packages/daemon/src/handlers/message-handler.ts`
+- 修改: `packages/daemon/src/control-server.ts`
+- 测试: `packages/daemon/src/handlers/message-handler.test.ts`
+- 测试: `packages/daemon/src/control-server.test.ts`
+
+- [x] **Step 1: 写失败测试 - GET messages 支持 conversationId 过滤**
+
+增加测试：
+
+```ts
+it('GET messages 应该优先返回指定 conversation 的历史消息', () => {
+  const messageStore = {
+    getByConversation: vi.fn().mockResolvedValue([{ id: 'msg-1', conversationId: 'conv-1' }]),
+    getByAgent: vi.fn(),
+    listConversations: vi.fn(),
+  };
+  const handler = createMessageHandler({ messageStore });
+
+  handler.handleGetMessages('agent:alice', mockReq('/api/v1/messages/agent%3Aalice?conversationId=conv-1'), res);
+
+  expect(messageStore.getByConversation).toHaveBeenCalledWith('agent:alice', 'conv-1', 50);
+});
+```
+
+- [x] **Step 2: 运行测试确认失败**
+
+运行: `npm test -w @f2a/daemon -- src/handlers/message-handler.test.ts`
+
+预期: FAIL，原因是当前 GET 只读内存队列。
+
+- [x] **Step 3: 写最小实现**
+
+把 `handleGetMessages` 改为 async 或内部 async IIFE：
+
+- 有 `conversationId`：调用 `messageStore.getByConversation(agentId, conversationId, limit)`。
+- 有 `peerAgentId`：调用 `messageStore.getByAgent(agentId, limit)` 后过滤。
+- 无历史查询参数：保持现有队列行为，避免破坏 `message list` 语义。
+
+- [x] **Step 4: 运行测试确认通过**
+
+运行: `npm test -w @f2a/daemon -- src/handlers/message-handler.test.ts`
+
+预期: PASS。
+
+- [x] **Step 5: 写失败测试 - 新 conversations 路由**
+
+在 `control-server.test.ts` 增加测试：
+
+```ts
+it('应该路由 GET /api/v1/conversations/:agentId 到 MessageHandler', async () => {
+  const res = await request(server).get('/api/v1/conversations/agent%3Aalice');
+  expect(res.status).not.toBe(405);
+});
+```
+
+在 handler 测试增加：
+
+```ts
+it('应该返回 Agent 的会话摘要列表', async () => {
+  const messageStore = {
+    listConversations: vi.fn().mockResolvedValue([{ conversationId: 'conv-1', peerAgentId: 'agent:bob', lastMessageAt: 1, messageCount: 1 }])
+  };
+  const handler = createMessageHandler({ messageStore });
+
+  await handler.handleListConversations('agent:alice', mockReq('/api/v1/conversations/agent%3Aalice'), res);
+
+  expect(json(res).conversations).toHaveLength(1);
+});
+```
+
+- [x] **Step 6: 运行测试确认失败**
+
+运行:
+
+```bash
+npm test -w @f2a/daemon -- src/handlers/message-handler.test.ts
+npm test -w @f2a/daemon -- src/control-server.test.ts
+```
+
+预期: FAIL，原因是路由和 handler 方法不存在。
+
+- [x] **Step 7: 写最小实现**
+
+新增路由：
+
+```ts
+const conversationsMatch = req.url?.match(/^\/api\/v1\/conversations\/([^\/?]+)(?:\?|$)/);
+```
+
+新增 handler：
+
+```ts
+handleListConversations(agentId: string, req: IncomingMessage, res: ServerResponse): void
+```
+
+读取 `limit`，调用 `messageStore.listConversations(agentId, limit)`。
+
+- [x] **Step 8: 运行测试确认通过**
+
+运行:
+
+```bash
+npm test -w @f2a/daemon -- src/handlers/message-handler.test.ts
+npm test -w @f2a/daemon -- src/control-server.test.ts
+```
+
+预期: PASS。
+
+### Task 4: CLI 支持 send conversation 参数和查询命令
+
+**文件：**
+- 修改: `packages/cli/src/main.ts`
+- 修改: `packages/cli/src/messages.ts`
+- 测试: `packages/cli/src/messages.test.ts`
+- 测试: `packages/cli/src/main.test.ts`
+
+- [x] **Step 1: 写失败测试 - send 传递 conversation 参数**
+
+在 `messages.test.ts` 增加：
+
+```ts
+it('send 应该传递 conversationId 和 replyToMessageId', async () => {
+  await sendMessage({
+    agentId: 'agent:alice',
+    toAgentId: 'agent:bob',
+    content: 'hello',
+    conversationId: 'conv-1',
+    replyToMessageId: 'msg-1'
+  });
+
+  expect(sendRequest).toHaveBeenCalledWith(
+    'POST',
+    '/api/v1/messages',
+    expect.objectContaining({
+      conversationId: 'conv-1',
+      replyToMessageId: 'msg-1'
+    }),
+    expect.any(Object)
+  );
+});
+```
+
+- [x] **Step 2: 运行测试确认失败**
+
+运行: `npm test -w @f2a/cli -- src/messages.test.ts`
+
+预期: FAIL，原因是 `sendMessage` options 不支持新字段。
+
+- [x] **Step 3: 写最小实现**
+
+`sendMessage` options 增加：
+
+```ts
+conversationId?: string;
+replyToMessageId?: string;
+```
+
+payload 传递两个字段。`main.ts` parse send options：
+
+```ts
+conversationId: sendOpts['conversation-id'] as string | undefined,
+replyToMessageId: sendOpts['reply-to'] as string | undefined,
+```
+
+- [x] **Step 4: 运行测试确认通过**
+
+运行: `npm test -w @f2a/cli -- src/messages.test.ts`
+
+预期: PASS。
+
+- [x] **Step 5: 写失败测试 - conversations/thread 命令**
+
+在 `messages.test.ts` 增加：
+
+```ts
+it('listConversations 应该调用 conversations API', async () => {
+  await listConversations({ agentId: 'agent:alice', limit: 20 });
+  expect(sendRequest).toHaveBeenCalledWith('GET', '/api/v1/conversations/agent:alice?limit=20');
+});
+
+it('getThread 应该调用 messages conversation 查询', async () => {
+  await getThread({ agentId: 'agent:alice', conversationId: 'conv-1', limit: 20 });
+  expect(sendRequest).toHaveBeenCalledWith('GET', '/api/v1/messages/agent:alice?limit=20&conversationId=conv-1');
+});
+```
+
+- [x] **Step 6: 运行测试确认失败**
+
+运行: `npm test -w @f2a/cli -- src/messages.test.ts`
+
+预期: FAIL，原因是 `listConversations/getThread` 不存在。
+
+- [x] **Step 7: 写最小实现**
+
+在 `messages.ts` 新增导出：
+
+```ts
+export async function listConversations(options: { agentId: string; limit?: number }): Promise<void>
+export async function getThread(options: { agentId: string; conversationId: string; limit?: number }): Promise<void>
+```
+
+`main.ts` 的 `handleMessageCommand` 增加子命令：
+
+- `conversations`
+- `thread`
+
+更新 `showMessageHelp()` 文案。
+
+- [x] **Step 8: 运行测试确认通过**
+
+运行:
+
+```bash
+npm test -w @f2a/cli -- src/messages.test.ts
+npm test -w @f2a/cli -- src/main.test.ts
+```
+
+预期: PASS。
+
+### Task 5: 集成类型检查和目标测试
+
+**文件：**
+- 修改: `docs/superpowers/plans/2026-04-25-conversation-layer.md` 勾选实际完成步骤
+
+- [x] **Step 1: 运行目标包测试**
+
+运行:
+
+```bash
+npm test -w @f2a/network -- src/core/message-store.test.ts
+npm test -w @f2a/daemon -- src/handlers/message-handler.test.ts
+npm test -w @f2a/daemon -- src/control-server.test.ts
+npm test -w @f2a/cli -- src/messages.test.ts
+npm test -w @f2a/cli -- src/main.test.ts
+```
+
+预期: PASS。
+
+- [x] **Step 2: 运行类型检查**
+
+运行: `npm run lint`
+
+预期: PASS。
+
+- [x] **Step 3: 检查工作区和总结**
+
+运行:
+
+```bash
+git status --short
+git diff --stat
+```
+
+预期: 只包含 Phase 1 相关代码、测试和计划文档。
+

--- a/docs/superpowers/specs/2026-04-25-conversation-layer-design.md
+++ b/docs/superpowers/specs/2026-04-25-conversation-layer-design.md
@@ -1,0 +1,259 @@
+# Phase 1: Conversation Layer Design
+
+> 状态：Draft，等待审阅批准后进入实施计划。
+
+---
+
+## 背景
+
+F2A 已经具备基础消息投递能力：CLI 通过 Daemon 发送消息，Daemon 使用 MessageRouter 将消息投递到本地 callback、Agent webhook 或内存队列。RFC013 已把 `noReply` 默认设为 true，解决 A2A 无限回复循环的第一层安全问题。
+
+下一步需要让 Agent 的多轮互动具备稳定上下文。没有 Conversation Layer，消息只能作为独立事件存在，后续的通讯录、印象系统、协作空间都缺少可靠数据源。
+
+仓库中已经存在 `packages/network/src/core/message-store.ts`，基于 SQLite 和 `better-sqlite3` 实现了消息历史存储，但目前它还没有被 Daemon 消息链路系统性接入，也缺少会话维度字段。
+
+---
+
+## 目标
+
+Phase 1 的目标是建立最小可用的会话层：
+
+- 所有 Daemon 发送/接收的 Agent 消息可以持久化到 SQLite。
+- 每条消息有可选 `conversationId` 和 `replyToMessageId`。
+- Daemon API 可以按 Agent 和 conversation 查询历史消息。
+- CLI 可以查看会话列表和某个会话的消息。
+- 设计保留对未来摘要、印象和协作系统的扩展点。
+
+---
+
+## 非目标
+
+Phase 1 不实现以下内容：
+
+- 分布式消息同步或云端漫游。
+- 复杂对话摘要。
+- 自动信任评分或印象系统。
+- 任务市场、竞标、经济系统。
+- 全量 Dashboard 改造。
+
+---
+
+## 推荐方案
+
+### 方案 A：接入现有 MessageStore 并增量扩展
+
+复用现有 SQLite MessageStore，增加会话字段和查询方法，然后在 Daemon 的 MessageHandler/MessageRouter 链路中写入消息。
+
+优点：
+
+- 改动小，符合当前代码资产。
+- 能快速跑通持久化历史查询。
+- 测试可以集中在 Store、Handler、CLI 三层。
+
+缺点：
+
+- MessageStore 当前结构偏通用消息记录，后续可能需要再次演进 schema。
+
+### 方案 B：新建 ConversationStore
+
+新增独立 ConversationStore，专门管理 conversations/messages 两张表。
+
+优点：
+
+- 数据模型更干净，适合长期 Social Layer。
+- Conversation 概念天然是一等对象。
+
+缺点：
+
+- 当前已有 MessageStore 会被边缘化，短期重复。
+- 改动面更大。
+
+### 方案 C：只扩展内存队列
+
+在 QueueManager 中增加 conversation 字段和查询。
+
+优点：
+
+- 最快，改动最小。
+
+缺点：
+
+- Daemon 重启即丢失，不满足 Social Layer 的基础要求。
+- 无法支撑搜索、印象和长期上下文。
+
+推荐采用方案 A：先接入现有 MessageStore，并把字段设计成可迁移到 ConversationStore 的形态。
+
+---
+
+## 数据模型
+
+### MessageRecord 扩展
+
+建议在现有 `messages` 表基础上增加字段：
+
+- `conversation_id TEXT`
+- `reply_to_message_id TEXT`
+- `direction TEXT`：`inbound`、`outbound`、`local`
+- `agent_id TEXT`：本地视角 Agent。
+- `peer_agent_id TEXT`：对方 Agent。
+- `metadata TEXT`：JSON 序列化 metadata。
+- `created_at INTEGER`：保留 timestamp 兼容，或逐步用 created_at 命名统一。
+
+最小兼容策略：
+
+- 保留现有 `id/from/to/type/timestamp/summary/payload`。
+- 用 `ALTER TABLE ADD COLUMN` 做幂等迁移。
+- 新字段可以为空，旧消息仍可查询。
+
+### ConversationId 生成
+
+规则：
+
+- 如果请求显式携带 `conversationId`，直接使用。
+- 如果携带 `replyToMessageId` 且能查到原消息，沿用原消息 conversationId。
+- 否则新建 `conv-${randomUUID()}`。
+
+这样既支持新 CLI/API，也兼容旧客户端。
+
+---
+
+## API 设计
+
+### POST /api/v1/messages
+
+请求体新增可选字段：
+
+```json
+{
+  "conversationId": "conv-...",
+  "replyToMessageId": "msg-..."
+}
+```
+
+响应体返回：
+
+```json
+{
+  "success": true,
+  "messageId": "msg-...",
+  "conversationId": "conv-..."
+}
+```
+
+### GET /api/v1/messages/:agentId
+
+保留现有接口，增加查询参数：
+
+- `conversationId`
+- `peerAgentId`
+- `limit`
+
+### GET /api/v1/conversations/:agentId
+
+新增接口，返回某个 Agent 的会话摘要列表：
+
+```json
+{
+  "success": true,
+  "agentId": "agent:...",
+  "conversations": [
+    {
+      "conversationId": "conv-...",
+      "peerAgentId": "agent:...",
+      "lastMessageAt": 1710000000000,
+      "messageCount": 3,
+      "lastSummary": "..."
+    }
+  ]
+}
+```
+
+---
+
+## CLI 设计
+
+在 `f2a message` 下新增：
+
+```bash
+f2a message conversations --agent-id <agentId>
+f2a message thread --agent-id <agentId> --conversation-id <conversationId>
+```
+
+发送消息时新增：
+
+```bash
+f2a message send --agent-id <agentId> --to <targetAgentId> --conversation-id <convId> "..."
+f2a message send --agent-id <agentId> --to <targetAgentId> --reply-to <messageId> "..."
+```
+
+输出要求：
+
+- 文本模式展示会话 ID、对方 Agent、最后消息时间和摘要。
+- JSON 模式返回结构化字段，方便 MCP/Agent 调用。
+
+---
+
+## 写入位置
+
+建议第一版在 Daemon `MessageHandler.handleSendMessage()` 中写 outgoing/local 持久化，因为这里已经拥有 from/to/content/type/metadata/noReply 的完整请求上下文。
+
+同时要考虑 webhook/queue 的入站消息。远程入站消息进入本地 Agent 时，最终通过 MessageRouter 路由，也需要落库。第一版可以在 MessageRouter 增加可选 `messageStore` 依赖，路由成功前后记录 inbound/local 消息。
+
+为了控制范围，实施可分两步：
+
+1. 先记录通过 Daemon API 发出的消息和本地投递消息。
+2. 再补齐 P2P 远程入站路径。
+
+---
+
+## 错误处理
+
+- 消息投递成功但历史写入失败：发送接口不应直接失败，但需要记录日志，并在响应中可选返回 `historyPersisted: false`。
+- 查询历史失败：返回 500 和稳定错误码 `MESSAGE_HISTORY_FAILED`。
+- 无效 conversationId/replyTo：返回 400 和 `INVALID_CONVERSATION_REFERENCE`。
+
+---
+
+## 测试策略
+
+### Store 单元测试
+
+- schema migration 幂等。
+- 新消息写入包含 conversationId/replyTo。
+- 按 agent、peerAgent、conversation 查询。
+- 旧记录缺少新字段时查询不崩溃。
+
+### Daemon handler 测试
+
+- POST /messages 返回 conversationId。
+- replyTo 能沿用原 conversation。
+- GET /messages 支持 conversationId 过滤。
+- GET /conversations 返回摘要列表。
+
+### CLI 测试
+
+- `message send --conversation-id` 参数解析。
+- `message send --reply-to` 参数解析。
+- `message conversations` 和 `message thread` JSON/文本输出。
+
+---
+
+## 验收标准
+
+- Daemon 重启后仍能查询历史消息。
+- 一次多轮 A2A 对话可以关联到同一个 conversation。
+- CLI/API 可以查看 Agent 与指定对方的会话历史。
+- 旧消息接口保持兼容，不破坏现有 `message list/clear/send`。
+
+---
+
+## 开放问题
+
+1. Phase 1 是否要求一次性覆盖 P2P 远程入站路径，还是先覆盖 Daemon API 发送链路？
+2. 是否要把 `conversationId` 提升到 `RoutableMessage` 顶层字段，还是第一版继续放在 metadata 中并由 MessageStore 解析？
+
+推荐答案：
+
+- 第一版先覆盖 Daemon API 发送链路和本地投递，再补 P2P 入站路径。
+- `conversationId` 应提升为 `RoutableMessage` 顶层字段，metadata 只保留扩展信息。
+

--- a/docs/testing/integration-test-plan.md
+++ b/docs/testing/integration-test-plan.md
@@ -1,0 +1,59 @@
+# F2A 集成测试方案
+
+> 状态：当前分支基线方案。重点覆盖 Phase 1 Conversation Layer，并为后续 P2P、CLI、OpenClaw 插件集成留出分层入口。
+
+## 背景
+
+当前分支的目标是让 Agent 间消息具备可查询、可持久化的会话历史。相关实现跨越 `@f2a/daemon` 的 HTTP API、`MessageHandler`、`MessageRouter`，以及 `@f2a/network` 的 `MessageStore` SQLite 存储。
+
+已有测试以单元测试为主，`packages/network/tests/integration/` 中的测试依赖外部运行节点和 `RUN_INTEGRATION_TESTS=true`，适合作为环境级验证，但不适合作为每次开发都能快速执行的最小集成基线。因此需要把集成测试拆成可本地快速运行的“进程内集成”和需要多节点环境的“系统集成”两层。
+
+## 测试分层
+
+| 层级 | 目标 | 运行方式 | 是否默认运行 |
+|------|------|----------|--------------|
+| 进程内集成 | 覆盖真实模块协作，不启动真实 P2P 多节点 | Vitest 启动真实 `ControlServer`，使用临时 `dataDir` 和 SQLite | 建议默认或 PR 必跑 |
+| 本地多进程集成 | 覆盖 CLI ↔ Daemon ↔ HTTP API 生命周期 | 启动 daemon 子进程，CLI 通过 HTTP 调用 | 手动或 nightly |
+| 多节点 P2P 集成 | 覆盖 libp2p 发现、连接、远程消息 | `RUN_INTEGRATION_TESTS=true` + Docker 或本地多节点 | CI 分阶段或手动 |
+| E2E 场景 | 覆盖完整用户流程和回归场景 | `packages/network/tests/e2e/scenarios` | 发布前 |
+
+## 当前分支最小验收链路
+
+Conversation Layer 的最小集成验证应覆盖以下链路：
+
+1. 启动真实 `ControlServer`，使用独立临时 `dataDir`。
+2. 通过 `POST /api/v1/agents` 注册两个 Agent，并拿到 agent token。
+3. 通过 `POST /api/v1/messages` 从 Agent A 发送消息给 Agent B，携带显式 `conversationId`。
+4. 通过 `GET /api/v1/conversations/:agentId` 查询 Agent A 和 Agent B 的会话摘要。
+5. 通过 `GET /api/v1/messages/:agentId?conversationId=...` 查询双方视角下的会话消息。
+6. 停止并重启 `ControlServer`，复用同一个 `dataDir`。
+7. 再次查询会话消息，确认 SQLite 历史仍可读。
+
+该测试不启动真实 P2P 网络。它验证的是当前分支最关键的跨模块契约：HTTP API、Agent 注册、Agent Token、MessageRouter 本地投递、MessageStore 持久化，以及 Daemon 重启后的历史读取。
+
+## 建议测试文件布局
+
+```text
+packages/daemon/tests/
+  conversation-history.integration.test.ts
+
+packages/network/tests/integration/
+  p2p-connection.test.ts
+  message-passing.test.ts
+  ...
+```
+
+`packages/daemon/tests/*.integration.test.ts` 用于快速、确定性的进程内集成。`packages/network/tests/integration/` 继续保留需要外部节点或 Docker 的网络级集成。
+
+## 后续扩展
+
+- CLI 集成：使用真实 daemon，覆盖 `f2a message conversations`、`f2a message thread` 和 `f2a message send --conversation-id`。
+- P2P 入站历史：启动两个 F2A 节点，验证远程 `agent.message` 经 `message:received` 事件落入接收方会话历史。
+- 兼容性迁移：准备旧版 `messages.db` fixture，验证 `MessageStore` 幂等迁移不会破坏历史记录。
+- 失败路径：验证历史写入失败时发送 API 返回 `historyPersisted: false` 且投递不被阻断。
+
+## 当前最小验证命令
+
+```bash
+npm test -w @f2a/daemon -- tests/conversation-history.integration.test.ts
+```

--- a/docs/testing/integration-test-plan.md
+++ b/docs/testing/integration-test-plan.md
@@ -31,6 +31,12 @@ Conversation Layer 的最小集成验证应覆盖以下链路：
 
 该测试不启动真实 P2P 网络。它验证的是当前分支最关键的跨模块契约：HTTP API、Agent 注册、Agent Token、MessageRouter 本地投递、MessageStore 持久化，以及 Daemon 重启后的历史读取。
 
+## 历史写入失败语义
+
+`POST /api/v1/messages` 的主职责是投递消息，历史持久化是附加能力。当前约定是：消息已经成功路由，但 SQLite 历史写入失败时，接口仍返回 `success: true`，同时返回 `historyPersisted: false`。
+
+调用方看到 `historyPersisted: false` 时应将消息视为“已投递但不可保证可回放”。CLI 或上层 Agent 应提示用户会话历史可能缺失，并可按业务需要重试发送、记录本地补偿日志，或稍后通过 `GET /api/v1/messages/:agentId?conversationId=...` 确认历史是否可查。
+
 ## 建议测试文件布局
 
 ```text

--- a/package-lock.json
+++ b/package-lock.json
@@ -6835,7 +6835,7 @@
       "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
-        "@f2a/network": "^0.7.5",
+        "@f2a/network": "*",
         "eventemitter3": "^5.0.4",
         "zod": "^3.22.4"
       },

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -23,7 +23,7 @@ import { readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { listAgents, registerAgent, unregisterAgent, updateAgent } from './agents.js';
-import { sendMessage, getMessages, clearMessages } from './messages.js';
+import { sendMessage, getMessages, clearMessages, listConversations, getThread } from './messages.js';
 import { startForeground, startBackground, stopDaemon, restartDaemon, showStatus } from './daemon.js';
 import { showIdentityStatus, exportIdentity, importIdentityInternal } from './identity.js';
 import { cliInitAgent, showAgentStatus } from './init.js';
@@ -60,7 +60,7 @@ Commands:
   node       P2P node management (init, status, peers, health, discover)
 
   agent      Agent management (init, register, list, unregister, status, update)
-  message    Message management (send, list, clear)
+  message    Message management (send, list, conversations, thread, clear)
   daemon     Daemon management (start, stop, restart, status, foreground)
   identity   Identity management (status, export, import)
 
@@ -144,18 +144,26 @@ Usage: f2a message <subcommand> [options]
 
 Subcommands:
   send              Send message to Agent
-                    f2a message send --agent-id <agentId> --to <agent_id> [--type <type>] [--expect-reply] [--reason <text>] "content"
+                    f2a message send --agent-id <agentId> --to <agent_id> [--type <type>] [--expect-reply] [--reason <text>] [--conversation-id <id>] [--reply-to <messageId>] "content"
                     --agent-id        Agent ID (required)
                     --to              Recipient Agent ID (optional, broadcasts if omitted)
                     --type            Message type: message, task_request, task_response, announcement, claim
                     --expect-reply    RFC 013: Explicitly declare expecting a reply (sets noReply=false)
                     --reason          RFC 013: Reason for not expecting reply (optional, stored in metadata.noReplyReason)
+                    --conversation-id Phase 1: Continue an existing conversation
+                    --reply-to        Phase 1: Reply to a specific message ID
                     --no-reply        RFC 013: Deprecated, kept for compatibility (no effect, defaults to noReply=true)
 
   list              View message queue
                     f2a message list --agent-id <agentId> [--unread] [--limit <n>]
                     --unread  Show only unread messages
                     --limit   Limit count
+
+  conversations     View conversation list
+                    f2a message conversations --agent-id <agentId> [--limit <n>]
+
+  thread            View one conversation thread
+                    f2a message thread --agent-id <agentId> --conversation-id <conversationId> [--limit <n>]
 
   clear             Clear messages
                     f2a message clear --agent-id <agentId>
@@ -165,6 +173,8 @@ Examples:
   f2a message send --agent-id agent:abc123... "Broadcast message"
   f2a message send --agent-id agent:abc123... --to agent:xyz789... --expect-reply "Task request (expecting reply)"
   f2a message send --agent-id agent:abc123... --to agent:xyz789... --reason "Task completed" "Result notification"
+  f2a message conversations --agent-id agent:abc123...
+  f2a message thread --agent-id agent:abc123... --conversation-id conv-abc...
   # Note: --no-reply is deprecated, messages default to noReply=true
 `);
 }
@@ -470,6 +480,9 @@ async function handleMessageCommand(subArgs: string[]): Promise<void> {
         expectReply: sendOpts['expect-reply'] as boolean | undefined,
         // RFC 013: --reason flag (optional reason for noReply)
         reason: sendOpts.reason as string | undefined,
+        // Phase 1: conversation threading
+        conversationId: sendOpts['conversation-id'] as string | undefined,
+        replyToMessageId: sendOpts['reply-to'] as string | undefined,
       });
       break;
 
@@ -479,6 +492,23 @@ async function handleMessageCommand(subArgs: string[]): Promise<void> {
         agentId: listOpts['agent-id'] as string,
         unread: listOpts.unread as boolean,
         limit: listOpts.limit ? parseInt(listOpts.limit as string, 10) : undefined,
+      });
+      break;
+
+    case 'conversations':
+      const conversationsOpts = parseArgs(restArgs);
+      await listConversations({
+        agentId: conversationsOpts['agent-id'] as string,
+        limit: conversationsOpts.limit ? parseInt(conversationsOpts.limit as string, 10) : undefined,
+      });
+      break;
+
+    case 'thread':
+      const threadOpts = parseArgs(restArgs);
+      await getThread({
+        agentId: threadOpts['agent-id'] as string,
+        conversationId: threadOpts['conversation-id'] as string,
+        limit: threadOpts.limit ? parseInt(threadOpts.limit as string, 10) : undefined,
       });
       break;
 

--- a/packages/cli/src/messages.test.ts
+++ b/packages/cli/src/messages.test.ts
@@ -7,7 +7,7 @@ process.exit = vi.fn() as any;
 process.env.F2A_CONTROL_TOKEN = '***';
 process.env.F2A_CONTROL_PORT = '9001';
 
-import { sendMessage, getMessages, clearMessages } from './messages.js';
+import { sendMessage, getMessages, clearMessages, listConversations, getThread } from './messages.js';
 import { request, RequestOptions } from 'http';
 import { isJsonMode, outputJson, outputError } from './output.js';
 
@@ -296,6 +296,37 @@ describe('CLI Messages Commands', () => {
         expect(payload.noReplyReason).toBe(testReason);
         // 默认情况下 noReply=true
         expect(payload.noReply).toBe(true);
+      });
+
+      it('conversationId 和 replyToMessageId 应传递到 payload', async () => {
+        const responseData = { success: true, messageId: 'msg:conversation', conversationId: 'conv-1' };
+
+        mockResponse.on.mockImplementation((event: string, callback: Function) => {
+          if (event === 'data') callback(Buffer.from(JSON.stringify(responseData)));
+          if (event === 'end') callback();
+        });
+
+        let capturedBody: string | null = null;
+        (request as any).mockImplementation((options: RequestOptions, callback: Function) => {
+          mockRequest.write.mockImplementation((data: string) => {
+            capturedBody = data;
+          });
+          callback(mockResponse);
+          return mockRequest;
+        });
+
+        await sendMessage({
+          agentId: 'agent:test:123',
+          toAgentId: 'agent:receiver:456',
+          content: 'conversation message',
+          conversationId: 'conv-1',
+          replyToMessageId: 'msg-original',
+        });
+
+        expect(capturedBody).not.toBeNull();
+        const payload = JSON.parse(capturedBody!);
+        expect(payload.conversationId).toBe('conv-1');
+        expect(payload.replyToMessageId).toBe('msg-original');
       });
 
       // 测试 Self-send + --expect-reply 报错
@@ -650,6 +681,86 @@ describe('CLI Messages Commands', () => {
         
         consoleErrorSpy.mockRestore();
       });
+    });
+  });
+
+  describe('conversation history', () => {
+    it('listConversations should call conversations API and output JSON', async () => {
+      const responseData = {
+        success: true,
+        conversations: [
+          {
+            conversationId: 'conv-1',
+            peerAgentId: 'agent:peer:456',
+            lastMessageAt: 2000,
+            messageCount: 2,
+            lastSummary: 'hello',
+          },
+        ],
+        count: 1,
+      };
+
+      mockResponse.on.mockImplementation((event: string, callback: Function) => {
+        if (event === 'data') callback(Buffer.from(JSON.stringify(responseData)));
+        if (event === 'end') callback();
+      });
+
+      let capturedPath = '';
+      (request as any).mockImplementation((options: RequestOptions, callback: Function) => {
+        capturedPath = options.path as string;
+        callback(mockResponse);
+        return mockRequest;
+      });
+
+      (isJsonMode as any).mockReturnValue(true);
+
+      await listConversations({ agentId: 'agent:test:123', limit: 20 });
+
+      expect(capturedPath).toBe('/api/v1/conversations/agent:test:123?limit=20');
+      expect(outputJson).toHaveBeenCalledWith({
+        conversations: responseData.conversations,
+        count: 1,
+      });
+
+      (isJsonMode as any).mockReturnValue(false);
+    });
+
+    it('getThread should call messages API with conversationId and output JSON', async () => {
+      const responseData = {
+        success: true,
+        messages: [
+          {
+            id: 'msg-1',
+            conversationId: 'conv-1',
+            content: 'hello',
+          },
+        ],
+        count: 1,
+      };
+
+      mockResponse.on.mockImplementation((event: string, callback: Function) => {
+        if (event === 'data') callback(Buffer.from(JSON.stringify(responseData)));
+        if (event === 'end') callback();
+      });
+
+      let capturedPath = '';
+      (request as any).mockImplementation((options: RequestOptions, callback: Function) => {
+        capturedPath = options.path as string;
+        callback(mockResponse);
+        return mockRequest;
+      });
+
+      (isJsonMode as any).mockReturnValue(true);
+
+      await getThread({ agentId: 'agent:test:123', conversationId: 'conv-1', limit: 20 });
+
+      expect(capturedPath).toBe('/api/v1/messages/agent:test:123?limit=20&conversationId=conv-1');
+      expect(outputJson).toHaveBeenCalledWith({
+        messages: responseData.messages,
+        count: 1,
+      });
+
+      (isJsonMode as any).mockReturnValue(false);
     });
   });
 });

--- a/packages/cli/src/messages.ts
+++ b/packages/cli/src/messages.ts
@@ -93,8 +93,23 @@ export async function sendMessage(options: {
   expectReply?: boolean;
   /** RFC 013: Optional reason for not expecting reply (stored in metadata.noReplyReason) */
   reason?: string;
+  /** Phase 1: Conversation ID */
+  conversationId?: string;
+  /** Phase 1: Reply target message ID */
+  replyToMessageId?: string;
 }): Promise<void> {
-  const { agentId, toAgentId, content, type, metadata, noReply, expectReply, reason } = options;
+  const {
+    agentId,
+    toAgentId,
+    content,
+    type,
+    metadata,
+    noReply,
+    expectReply,
+    reason,
+    conversationId,
+    replyToMessageId
+  } = options;
 
   if (!agentId) {
     if (isJsonMode()) {
@@ -184,6 +199,8 @@ export async function sendMessage(options: {
       metadata,
       noReply: actualNoReply,
       noReplyReason: reason,
+      conversationId,
+      replyToMessageId,
     };
 
     const result = await sendRequest(
@@ -194,6 +211,193 @@ export async function sendMessage(options: {
     );
 
     handleSendResult(result, agentId, toAgentId);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (isJsonMode()) {
+      outputError(`Cannot connect to Daemon: ${message}`, 'DAEMON_NOT_RUNNING');
+      return;
+    }
+    console.error(`❌ Error: Cannot connect to Daemon: ${message}`);
+    console.error('Please ensure Daemon is running: f2a daemon start');
+    process.exit(1);
+  }
+}
+
+/**
+ * List conversations
+ * f2a message conversations --agent-id <agentId> [--limit <n>]
+ */
+export async function listConversations(options: {
+  agentId: string;
+  limit?: number;
+}): Promise<void> {
+  if (!options.agentId) {
+    if (isJsonMode()) {
+      outputError('Missing required --agent-id parameter', 'MISSING_AGENT_ID');
+    } else {
+      console.error('❌ Error: Missing required --agent-id parameter.');
+      console.error('Usage: f2a message conversations --agent-id <agentId>');
+      process.exit(1);
+    }
+    return;
+  }
+
+  const limit = options.limit || 50;
+
+  try {
+    const result = await sendRequest('GET', `/api/v1/conversations/${options.agentId}?limit=${limit}`);
+
+    if (result.success) {
+      const conversations = (result.conversations || []) as Array<{
+        conversationId: string;
+        peerAgentId: string;
+        lastMessageAt: number;
+        messageCount: number;
+        lastSummary?: string;
+      }>;
+
+      if (isJsonMode()) {
+        outputJson({
+          conversations,
+          count: conversations.length,
+        });
+        return;
+      }
+
+      if (conversations.length === 0) {
+        console.log('📭 No conversations found.');
+        return;
+      }
+
+      console.log(`💬 Conversations (${conversations.length}):`);
+      console.log('');
+      for (const conversation of conversations) {
+        const time = new Date(conversation.lastMessageAt).toLocaleString('en-US');
+        console.log(`${conversation.conversationId} ↔ ${conversation.peerAgentId}`);
+        console.log(`   Messages: ${conversation.messageCount} | Last: ${time}`);
+        if (conversation.lastSummary) {
+          console.log(`   ${conversation.lastSummary}`);
+        }
+        console.log('');
+      }
+    } else {
+      if (isJsonMode()) {
+        outputError(`Failed to list conversations: ${result.error}`, 'CONVERSATIONS_FAILED');
+        return;
+      }
+      console.error(`❌ Error: Failed to list conversations: ${result.error}`);
+      process.exit(1);
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (isJsonMode()) {
+      outputError(`Cannot connect to Daemon: ${message}`, 'DAEMON_NOT_RUNNING');
+      return;
+    }
+    console.error(`❌ Error: Cannot connect to Daemon: ${message}`);
+    console.error('Please ensure Daemon is running: f2a daemon start');
+    process.exit(1);
+  }
+}
+
+/**
+ * Get conversation thread
+ * f2a message thread --agent-id <agentId> --conversation-id <conversationId> [--limit <n>]
+ */
+export async function getThread(options: {
+  agentId: string;
+  conversationId: string;
+  limit?: number;
+}): Promise<void> {
+  if (!options.agentId) {
+    if (isJsonMode()) {
+      outputError('Missing required --agent-id parameter', 'MISSING_AGENT_ID');
+    } else {
+      console.error('❌ Error: Missing required --agent-id parameter.');
+      console.error('Usage: f2a message thread --agent-id <agentId> --conversation-id <conversationId>');
+      process.exit(1);
+    }
+    return;
+  }
+
+  if (!options.conversationId) {
+    if (isJsonMode()) {
+      outputError('Missing required --conversation-id parameter', 'MISSING_CONVERSATION_ID');
+    } else {
+      console.error('❌ Error: Missing required --conversation-id parameter.');
+      console.error('Usage: f2a message thread --agent-id <agentId> --conversation-id <conversationId>');
+      process.exit(1);
+    }
+    return;
+  }
+
+  const limit = options.limit || 50;
+
+  try {
+    const result = await sendRequest(
+      'GET',
+      `/api/v1/messages/${options.agentId}?limit=${limit}&conversationId=${options.conversationId}`
+    );
+
+    if (result.success) {
+      const messages = (result.messages || []) as Array<{
+        id?: string;
+        messageId?: string;
+        from?: string;
+        to?: string;
+        fromAgentId?: string;
+        toAgentId?: string;
+        content?: string;
+        payload?: string;
+        type?: string;
+        timestamp?: number;
+        createdAt?: string;
+      }>;
+
+      if (isJsonMode()) {
+        outputJson({
+          messages,
+          count: messages.length,
+        });
+        return;
+      }
+
+      if (messages.length === 0) {
+        console.log('📭 No messages found in this conversation.');
+        return;
+      }
+
+      console.log(`🧵 Thread ${options.conversationId} (${messages.length}):`);
+      console.log('');
+      for (const msg of messages) {
+        const from = msg.fromAgentId || msg.from || 'unknown';
+        const to = msg.toAgentId || msg.to || 'unknown';
+        const time = msg.createdAt
+          ? new Date(msg.createdAt).toLocaleString('en-US')
+          : msg.timestamp
+            ? new Date(msg.timestamp).toLocaleString('en-US')
+            : '';
+        let content = msg.content || '';
+        if (!content && msg.payload) {
+          try {
+            const payload = JSON.parse(msg.payload) as { content?: string };
+            content = payload.content || msg.payload;
+          } catch {
+            content = msg.payload;
+          }
+        }
+        console.log(`[${msg.type || 'message'}] ${from} → ${to} (${time})`);
+        console.log(`   ${content}`);
+        console.log('');
+      }
+    } else {
+      if (isJsonMode()) {
+        outputError(`Failed to get thread: ${result.error}`, 'THREAD_FAILED');
+        return;
+      }
+      console.error(`❌ Error: Failed to get thread: ${result.error}`);
+      process.exit(1);
+    }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     if (isJsonMode()) {

--- a/packages/daemon/src/control-server.test.ts
+++ b/packages/daemon/src/control-server.test.ts
@@ -416,6 +416,35 @@ describe('ControlServer', () => {
     });
   });
 
+  describe('GET /api/v1/conversations/:agentId', () => {
+    it('should route conversations request to message handler', async () => {
+      mockRateLimiterAllow = true;
+      mockF2A.getAgentRegistry().get.mockReturnValue({
+        agentId: 'agent:test-peer:abc123',
+        name: 'TestAgent',
+      });
+      await server.start();
+
+      const handler = lastMockServer._handler;
+      const req = createMockReq({
+        method: 'GET',
+        url: '/api/v1/conversations/agent%3Atest-peer%3Aabc123?limit=10',
+      });
+      const res = createMockRes();
+
+      handler(req, res);
+      await new Promise(resolve => setTimeout(resolve, 20));
+
+      expect(res.writeHead).toHaveBeenCalledWith(200);
+      const responseData = JSON.parse(res.end.mock.calls[0][0]);
+      expect(responseData.success).toBe(true);
+      expect(responseData.agentId).toBe('agent:test-peer:abc123');
+      expect(Array.isArray(responseData.conversations)).toBe(true);
+
+      server.stop();
+    });
+  });
+
   describe('POST /api/v1/agents (RFC008)', () => {
     it('should register agent with publicKey', async () => {
       mockRateLimiterAllow = true;

--- a/packages/daemon/src/control-server.test.ts
+++ b/packages/daemon/src/control-server.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ControlServer } from './control-server.js';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { randomUUID } from 'crypto';
+import { MessageStore } from '@f2a/network';
+import { mkdirSync } from 'fs';
 
 // Track mock server instances
 let lastMockServer: any = null;
@@ -203,7 +206,8 @@ const createMockF2A = () => {
     load: vi.fn(),
   };
   
-  const mockMessageRouter = {
+  const messageRouterListeners = new Map<string, Function[]>();
+  const mockMessageRouter: any = {
     route: vi.fn().mockResolvedValue({ success: true }),
     routeLocal: vi.fn().mockResolvedValue({ success: true }),
     routeRemote: vi.fn().mockResolvedValue({ success: true }),
@@ -211,6 +215,18 @@ const createMockF2A = () => {
     getQueue: vi.fn(),
     clearQueue: vi.fn(),
     sendMessage: vi.fn().mockResolvedValue({ success: true }),
+    on: vi.fn((event: string, handler: Function) => {
+      const listeners = messageRouterListeners.get(event) || [];
+      listeners.push(handler);
+      messageRouterListeners.set(event, listeners);
+      return mockMessageRouter;
+    }),
+    emit: vi.fn((event: string, ...args: unknown[]) => {
+      for (const handler of messageRouterListeners.get(event) || []) {
+        handler(...args);
+      }
+      return true;
+    }),
   };
   
   // P0 修复：添加 identityManager mock
@@ -273,6 +289,7 @@ const createMockF2A = () => {
 describe('ControlServer', () => {
   let mockF2A: any;
   let server: ControlServer;
+  let testDataDir: string;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -283,7 +300,9 @@ describe('ControlServer', () => {
     // P0: Reset mockImplementation on registry.get (vi.clearAllMocks doesn't clear mockImplementation)
     mockF2A.getAgentRegistry().get.mockReset();
     mockF2A.getMessageRouter().route.mockReset();
-    server = new ControlServer(mockF2A, 9001, undefined, { dataDir: join(tmpdir(), 'f2a-test') });
+    testDataDir = join(tmpdir(), `f2a-test-${randomUUID()}`);
+    mkdirSync(testDataDir, { recursive: true });
+    server = new ControlServer(mockF2A, 9001, undefined, { dataDir: testDataDir });
   });
 
   afterEach(() => {
@@ -442,6 +461,43 @@ describe('ControlServer', () => {
       expect(Array.isArray(responseData.conversations)).toBe(true);
 
       server.stop();
+    });
+  });
+
+  describe('P2P inbound history', () => {
+    it('should persist message:received events as inbound conversation history', async () => {
+      const router = mockF2A.getMessageRouter();
+
+      router.emit('message:received', {
+        messageId: 'msg-p2p-inbound',
+        fromAgentId: 'agent:remote',
+        toAgentId: 'agent:test-peer:abc123',
+        content: 'hello from p2p',
+        type: 'message',
+        createdAt: new Date('2026-04-25T00:00:00.000Z'),
+        metadata: {
+          conversationId: 'conv-p2p',
+          replyToMessageId: 'msg-parent',
+        },
+      });
+
+      await new Promise(resolve => setTimeout(resolve, 20));
+
+      const store = new MessageStore({ dbPath: join(testDataDir, 'messages.db') });
+      const messages = await store.getByConversation('agent:test-peer:abc123', 'conv-p2p', 10);
+      store.close();
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toMatchObject({
+        id: 'msg-p2p-inbound',
+        from: 'agent:remote',
+        to: 'agent:test-peer:abc123',
+        conversationId: 'conv-p2p',
+        replyToMessageId: 'msg-parent',
+        agentId: 'agent:test-peer:abc123',
+        peerAgentId: 'agent:remote',
+        direction: 'inbound',
+      });
     });
   });
 

--- a/packages/daemon/src/control-server.ts
+++ b/packages/daemon/src/control-server.ts
@@ -21,6 +21,7 @@ import { RateLimiter } from '@f2a/network';
 import { getErrorMessage } from '@f2a/network';
 import { E2EECrypto } from '@f2a/network';
 import { AgentRegistry, MessageRouter } from '@f2a/network';
+import { MessageStore } from '@f2a/network';
 import { AgentIdentityStore } from './agent-identity-store.js';
 import { AgentTokenManager } from './agent-token-manager.js';
 import { AgentHandler } from './handlers/agent-handler.js';
@@ -100,6 +101,7 @@ export class ControlServer {
   // Phase 1: Agent 注册表和消息路由器
   private agentRegistry: AgentRegistry;
   private messageRouter: MessageRouter;
+  private messageStore: MessageStore;
   // Phase 6: Agent Identity Manager
   private identityStore: AgentIdentityStore;
   // Phase 7: E2EECrypto 用于签名验证
@@ -137,6 +139,9 @@ export class ControlServer {
     // 避免创建独立实例导致数据不一致
     this.agentRegistry = f2a.getAgentRegistry();
     this.messageRouter = f2a.getMessageRouter();
+    this.messageStore = new MessageStore({
+      dbPath: join(this.dataDir, 'messages.db'),
+    });
     
     // Phase 6: 初始化 Identity Manager（daemon 特有的 Agent 身份持久化）
     this.identityStore = new AgentIdentityStore(this.dataDir);
@@ -183,6 +188,7 @@ export class ControlServer {
       agentRegistry: this.agentRegistry,
       f2a: this.f2a,
       agentTokenManager: this.agentTokenManager,
+      messageStore: this.messageStore,
       logger: this.logger,
     });
 
@@ -277,6 +283,7 @@ export class ControlServer {
     }
     // 清理速率限制器资源
     this.rateLimiter.stop();
+    this.messageStore.close();
     this.logger.info('Stopped');
   }
 
@@ -405,6 +412,13 @@ export class ControlServer {
     const getMessagesMatch = req.url?.match(/^\/api\/v1\/messages\/([^\/?]+)(?:\?|$)/);
     if (req.method === 'GET' && getMessagesMatch) {
       this.messageHandler.handleGetMessages(decodeURIComponent(getMessagesMatch[1]), req, res);
+      return;
+    }
+
+    // GET /api/v1/conversations/:agentId - 获取 Agent 的会话摘要列表
+    const getConversationsMatch = req.url?.match(/^\/api\/v1\/conversations\/([^\/?]+)(?:\?|$)/);
+    if (req.method === 'GET' && getConversationsMatch) {
+      this.messageHandler.handleListConversations(decodeURIComponent(getConversationsMatch[1]), req, res);
       return;
     }
     

--- a/packages/daemon/src/control-server.ts
+++ b/packages/daemon/src/control-server.ts
@@ -11,6 +11,7 @@
  */
 
 import { createServer, Server, IncomingMessage, ServerResponse } from 'http';
+import { randomUUID } from 'crypto';
 import { homedir } from 'os';
 import { join } from 'path';
 import { existsSync, readFileSync } from 'fs';
@@ -21,7 +22,8 @@ import { RateLimiter } from '@f2a/network';
 import { getErrorMessage } from '@f2a/network';
 import { E2EECrypto } from '@f2a/network';
 import { AgentRegistry, MessageRouter } from '@f2a/network';
-import { MessageStore } from '@f2a/network';
+import { MessageStore, createMessageRecord } from '@f2a/network';
+import type { RoutableMessage } from '@f2a/network';
 import { AgentIdentityStore } from './agent-identity-store.js';
 import { AgentTokenManager } from './agent-token-manager.js';
 import { AgentHandler } from './handlers/agent-handler.js';
@@ -191,6 +193,7 @@ export class ControlServer {
       messageStore: this.messageStore,
       logger: this.logger,
     });
+    this.setupInboundMessageHistoryPersistence();
 
     this.systemHandler = new SystemHandler({
       f2a: this.f2a,
@@ -245,6 +248,66 @@ export class ControlServer {
    */
   getMessageRouter(): MessageRouter {
     return this.messageRouter;
+  }
+
+  /**
+   * 订阅 P2P 入站路由事件，将远程消息持久化到本地会话历史。
+   */
+  private setupInboundMessageHistoryPersistence(): void {
+    this.messageRouter.on('message:received', (message) => {
+      void this.persistInboundMessageHistory(message);
+    });
+  }
+
+  /**
+   * 持久化 P2P 入站消息。历史写入失败不影响路由投递。
+   */
+  private async persistInboundMessageHistory(message: RoutableMessage): Promise<void> {
+    if (!message.toAgentId) {
+      return;
+    }
+
+    try {
+      const metadata = message.metadata || {};
+      const conversationId = typeof metadata.conversationId === 'string'
+        ? metadata.conversationId
+        : `conv-${randomUUID()}`;
+      const replyToMessageId = typeof metadata.replyToMessageId === 'string'
+        ? metadata.replyToMessageId
+        : undefined;
+
+      await this.messageStore.add(createMessageRecord(
+        message.messageId,
+        message.fromAgentId,
+        message.toAgentId,
+        message.type,
+        message.createdAt.getTime(),
+        message.content.slice(0, 200),
+        {
+          content: message.content,
+          type: message.type,
+          metadata,
+          messageId: message.messageId,
+        },
+        {
+          conversationId,
+          replyToMessageId,
+          direction: 'inbound',
+          agentId: message.toAgentId,
+          peerAgentId: message.fromAgentId,
+          metadata: {
+            ...metadata,
+            messageId: message.messageId,
+          },
+          createdAt: message.createdAt.getTime(),
+        }
+      ));
+    } catch (error) {
+      this.logger.warn('Failed to persist inbound message history', {
+        messageId: message.messageId,
+        error: getErrorMessage(error),
+      });
+    }
   }
 
   /**

--- a/packages/daemon/src/handlers/agent-handler.ts
+++ b/packages/daemon/src/handlers/agent-handler.ts
@@ -14,7 +14,7 @@
 
 import type { IncomingMessage, ServerResponse } from 'http';
 import { randomBytes } from 'crypto';
-import { Logger, getErrorMessage, E2EECrypto, verifySelfSignature, computeAgentId } from '@f2a/network';
+import { Logger, getErrorMessage, E2EECrypto, verifySelfSignature, generateAgentId } from '@f2a/network';
 import type { AgentRegistry, AgentRegistration, MessageRouter, AgentCapability } from '@f2a/network';
 import type { AgentIdentityStore, AgentIdentity } from '../agent-identity-store.js';
 import type { AgentTokenManager } from '../agent-token-manager.js';
@@ -292,7 +292,7 @@ export class AgentHandler {
         }
 
         // RFC011: 验证 selfSignature 是否有效
-        const agentIdFromPublicKey = computeAgentId(data.publicKey);
+        const agentIdFromPublicKey = generateAgentId(data.publicKey);
         const selfSigValid = verifySelfSignature(
           agentIdFromPublicKey,
           data.publicKey,

--- a/packages/daemon/src/handlers/message-handler.test.ts
+++ b/packages/daemon/src/handlers/message-handler.test.ts
@@ -9,6 +9,7 @@ import { MessageHandler } from './message-handler.js';
 import type { MessageRouter, AgentRegistry, F2A } from '@f2a/network';
 import type { AgentTokenManager } from '../agent-token-manager.js';
 import type { Logger } from '@f2a/network';
+import type { MessageStore } from '@f2a/network';
 
 // Mock 依赖
 const createMockLogger = () => ({
@@ -87,6 +88,18 @@ const createMockMessageRouter = (): MessageRouter => ({
   unsubscribe: vi.fn(),
 });
 
+const createMockMessageStore = (): MessageStore => ({
+  add: vi.fn().mockResolvedValue(undefined),
+  getRecent: vi.fn().mockResolvedValue([]),
+  getByAgent: vi.fn().mockResolvedValue([]),
+  getByConversation: vi.fn().mockResolvedValue([]),
+  getByMessageId: vi.fn().mockResolvedValue(undefined),
+  listConversations: vi.fn().mockResolvedValue([]),
+  clear: vi.fn().mockResolvedValue(undefined),
+  close: vi.fn(),
+  getStats: vi.fn().mockReturnValue({ count: 0 }),
+} as unknown as MessageStore);
+
 const createMockF2A = (): F2A => ({
   peerId: 'test-peer-id',
   agentInfo: {
@@ -162,6 +175,7 @@ describe('MessageHandler - Error Response Code Field', () => {
   let mockRegistry: ReturnType<typeof createMockAgentRegistry>;
   let mockTokenManager: ReturnType<typeof createMockAgentTokenManager>;
   let mockMessageRouter: ReturnType<typeof createMockMessageRouter>;
+  let mockMessageStore: ReturnType<typeof createMockMessageStore>;
   let mockF2A: ReturnType<typeof createMockF2A>;
   let mockLogger: ReturnType<typeof createMockLogger>;
 
@@ -170,6 +184,7 @@ describe('MessageHandler - Error Response Code Field', () => {
     mockRegistry = createMockAgentRegistry();
     mockTokenManager = createMockAgentTokenManager();
     mockMessageRouter = createMockMessageRouter();
+    mockMessageStore = createMockMessageStore();
     mockF2A = createMockF2A();
     mockLogger = createMockLogger();
 
@@ -178,6 +193,7 @@ describe('MessageHandler - Error Response Code Field', () => {
       agentRegistry: mockRegistry,
       f2a: mockF2A,
       agentTokenManager: mockTokenManager,
+      messageStore: mockMessageStore,
       logger: mockLogger,
     });
   });
@@ -470,6 +486,85 @@ describe('MessageHandler - Error Response Code Field', () => {
       const data = getResponseData(res);
       expect(data.success).toBe(true);
       expect(data.messageId).toBeDefined();
+    });
+
+    it('成功发送消息时应生成 conversationId 并持久化历史', async () => {
+      const req = createMockReq({
+        method: 'POST',
+        body: {
+          fromAgentId: 'agent:test-peer:abc123',
+          toAgentId: 'agent:test-peer:xyz789',
+          content: 'Hello with history',
+        },
+        headers: { authorization: 'agent-test-token' },
+      });
+      (mockRegistry.get as any).mockReturnValue({ agentId: 'test', name: 'Test' });
+      (mockTokenManager.verifyForAgent as any).mockReturnValue({ valid: true });
+      (mockMessageRouter.routeAsync as any).mockResolvedValue(true);
+      const res = createMockRes();
+
+      await handler.handleSendMessage(req as IncomingMessage, res as ServerResponse);
+
+      await new Promise(resolve => setTimeout(resolve, 20));
+
+      expect(res.writeHead).toHaveBeenCalledWith(200);
+      const data = getResponseData(res);
+      expect(data.success).toBe(true);
+      expect(data.conversationId).toMatch(/^conv-/);
+      expect(data.historyPersisted).toBe(true);
+      expect(mockMessageStore.add).toHaveBeenCalledWith(expect.objectContaining({
+        id: data.messageId,
+        from: 'agent:test-peer:abc123',
+        to: 'agent:test-peer:xyz789',
+        type: 'message',
+        conversationId: data.conversationId,
+        agentId: 'agent:test-peer:abc123',
+        peerAgentId: 'agent:test-peer:xyz789',
+        direction: 'outbound',
+      }));
+      expect(mockMessageStore.add).toHaveBeenCalledWith(expect.objectContaining({
+        id: `${data.messageId}:inbound:agent:test-peer:xyz789`,
+        from: 'agent:test-peer:abc123',
+        to: 'agent:test-peer:xyz789',
+        type: 'message',
+        conversationId: data.conversationId,
+        agentId: 'agent:test-peer:xyz789',
+        peerAgentId: 'agent:test-peer:abc123',
+        direction: 'inbound',
+      }));
+    });
+
+    it('replyToMessageId 命中历史时应沿用原 conversationId', async () => {
+      (mockMessageStore.getByMessageId as any).mockResolvedValue({
+        id: 'msg-original',
+        conversationId: 'conv-existing',
+      });
+      const req = createMockReq({
+        method: 'POST',
+        body: {
+          fromAgentId: 'agent:test-peer:abc123',
+          toAgentId: 'agent:test-peer:xyz789',
+          content: 'Reply with history',
+          replyToMessageId: 'msg-original',
+        },
+        headers: { authorization: 'agent-test-token' },
+      });
+      (mockRegistry.get as any).mockReturnValue({ agentId: 'test', name: 'Test' });
+      (mockTokenManager.verifyForAgent as any).mockReturnValue({ valid: true });
+      (mockMessageRouter.routeAsync as any).mockResolvedValue(true);
+      const res = createMockRes();
+
+      await handler.handleSendMessage(req as IncomingMessage, res as ServerResponse);
+
+      await new Promise(resolve => setTimeout(resolve, 20));
+
+      expect(res.writeHead).toHaveBeenCalledWith(200);
+      const data = getResponseData(res);
+      expect(data.conversationId).toBe('conv-existing');
+      expect(mockMessageStore.add).toHaveBeenCalledWith(expect.objectContaining({
+        conversationId: 'conv-existing',
+        replyToMessageId: 'msg-original',
+      }));
     });
 
     // RFC 013: noReply 默认值测试
@@ -773,6 +868,79 @@ describe('MessageHandler - Error Response Code Field', () => {
       expect(data.agentId).toBe('agent:test-peer:abc123');
       expect(data.messages).toHaveLength(2);
       expect(data.count).toBe(2);
+    });
+
+    it('指定 conversationId 时应返回历史消息', async () => {
+      (mockRegistry.get as any).mockReturnValue({
+        agentId: 'agent:test-peer:abc123',
+        name: 'TestAgent',
+      });
+      (mockMessageStore.getByConversation as any).mockResolvedValue([
+        { id: 'msg-1', conversationId: 'conv-1', content: 'Hello' },
+      ]);
+      const req = createMockReq({ url: '/api/v1/messages/agent:test-peer:abc123?conversationId=conv-1&limit=10' });
+      const res = createMockRes();
+
+      handler.handleGetMessages('agent:test-peer:abc123', req as IncomingMessage, res as ServerResponse);
+      await new Promise(resolve => setTimeout(resolve, 20));
+
+      expect(mockMessageStore.getByConversation).toHaveBeenCalledWith(
+        'agent:test-peer:abc123',
+        'conv-1',
+        10
+      );
+      expect(res.writeHead).toHaveBeenCalledWith(200);
+      const data = getResponseData(res);
+      expect(data.success).toBe(true);
+      expect(data.messages).toHaveLength(1);
+      expect(data.source).toBe('history');
+    });
+  });
+
+  describe('GET /api/v1/conversations/:agentId - 获取会话列表', () => {
+    it('Agent 不存在应返回 404 + code: AGENT_NOT_FOUND', async () => {
+      (mockRegistry.get as any).mockReturnValue(undefined);
+      const req = createMockReq({ url: '/api/v1/conversations/agent:nonexistent' });
+      const res = createMockRes();
+
+      handler.handleListConversations('agent:nonexistent', req as IncomingMessage, res as ServerResponse);
+
+      await new Promise(resolve => setTimeout(resolve, 20));
+
+      expect(res.writeHead).toHaveBeenCalledWith(404);
+      const data = getResponseData(res);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe('Agent not found');
+      expect(data.code).toBe('AGENT_NOT_FOUND');
+    });
+
+    it('Agent 存在应返回会话摘要列表', async () => {
+      (mockRegistry.get as any).mockReturnValue({
+        agentId: 'agent:test-peer:abc123',
+        name: 'TestAgent',
+      });
+      (mockMessageStore.listConversations as any).mockResolvedValue([
+        {
+          conversationId: 'conv-1',
+          peerAgentId: 'agent:test-peer:xyz789',
+          lastMessageAt: 2000,
+          messageCount: 2,
+          lastSummary: 'hello',
+        },
+      ]);
+      const req = createMockReq({ url: '/api/v1/conversations/agent:test-peer:abc123?limit=10' });
+      const res = createMockRes();
+
+      handler.handleListConversations('agent:test-peer:abc123', req as IncomingMessage, res as ServerResponse);
+
+      await new Promise(resolve => setTimeout(resolve, 20));
+
+      expect(mockMessageStore.listConversations).toHaveBeenCalledWith('agent:test-peer:abc123', 10);
+      expect(res.writeHead).toHaveBeenCalledWith(200);
+      const data = getResponseData(res);
+      expect(data.success).toBe(true);
+      expect(data.conversations).toHaveLength(1);
+      expect(data.count).toBe(1);
     });
   });
 

--- a/packages/daemon/src/handlers/message-handler.ts
+++ b/packages/daemon/src/handlers/message-handler.ts
@@ -11,10 +11,11 @@
 
 import type { IncomingMessage, ServerResponse } from 'http';
 import { randomUUID } from 'crypto';
-import { Logger, getErrorMessage } from '@f2a/network';
+import { Logger, getErrorMessage, createMessageRecord } from '@f2a/network';
 import type { MessageRouter, RoutableMessage, AgentRegistry, F2A } from '@f2a/network';
 import type { MessageHandlerDeps } from '../types/handlers.js';
 import type { AgentTokenManager } from '../agent-token-manager.js';
+import type { MessageStore } from '@f2a/network';
 
 /**
  * 发送消息请求体类型
@@ -34,6 +35,10 @@ interface SendMessageBody {
   noReply?: boolean;
   /** RFC 013: 可选的不期待回复的原因（自由文本） */
   noReplyReason?: string;
+  /** Phase 1: 会话 ID */
+  conversationId?: string;
+  /** Phase 1: 回复的消息 ID */
+  replyToMessageId?: string;
 }
 
 /**
@@ -49,6 +54,7 @@ export class MessageHandler {
   private f2a: F2A;
   private logger: Logger;
   private agentTokenManager: AgentTokenManager;
+  private messageStore?: MessageStore;
 
   constructor(deps: MessageHandlerDeps) {
     this.messageRouter = deps.messageRouter;
@@ -56,6 +62,112 @@ export class MessageHandler {
     this.f2a = deps.f2a;
     this.logger = deps.logger;
     this.agentTokenManager = deps.agentTokenManager;
+    this.messageStore = deps.messageStore;
+  }
+
+  /**
+   * 解析会话 ID：显式 conversationId > replyTo 历史 > 新会话
+   */
+  private async resolveConversationId(data: SendMessageBody): Promise<string> {
+    if (data.conversationId) {
+      return data.conversationId;
+    }
+
+    if (data.replyToMessageId && this.messageStore) {
+      const original = await this.messageStore.getByMessageId(data.replyToMessageId);
+      if (original?.conversationId) {
+        return original.conversationId;
+      }
+    }
+
+    return `conv-${randomUUID()}`;
+  }
+
+  /**
+   * 持久化消息历史。历史写入失败不阻断投递。
+   */
+  private async persistMessageForAgent(
+    message: RoutableMessage,
+    conversationId: string,
+    agentId: string,
+    peerAgentId: string,
+    direction: 'inbound' | 'outbound' | 'local',
+    replyToMessageId?: string
+  ): Promise<void> {
+    const id = direction === 'outbound' || direction === 'local'
+      ? message.messageId
+      : `${message.messageId}:inbound:${agentId}`;
+
+    await this.messageStore!.add(createMessageRecord(
+      id,
+      message.fromAgentId,
+      message.toAgentId || '',
+      message.type,
+      message.createdAt.getTime(),
+      message.content.slice(0, 200),
+      {
+        content: message.content,
+        type: message.type,
+        metadata: message.metadata,
+        messageId: message.messageId,
+      },
+      {
+        conversationId,
+        replyToMessageId,
+        direction,
+        agentId,
+        peerAgentId,
+        metadata: {
+          ...message.metadata,
+          messageId: message.messageId,
+        },
+        createdAt: message.createdAt.getTime(),
+      }
+    ));
+  }
+
+  private async persistMessage(message: RoutableMessage, conversationId: string, replyToMessageId?: string): Promise<boolean> {
+    if (!this.messageStore) {
+      return false;
+    }
+
+    try {
+      if (!message.toAgentId || message.fromAgentId === message.toAgentId) {
+        await this.persistMessageForAgent(
+          message,
+          conversationId,
+          message.fromAgentId,
+          message.toAgentId || '',
+          'local',
+          replyToMessageId
+        );
+        return true;
+      }
+
+      await this.persistMessageForAgent(
+        message,
+        conversationId,
+        message.fromAgentId,
+        message.toAgentId,
+        'outbound',
+        replyToMessageId
+      );
+      await this.persistMessageForAgent(
+        message,
+        conversationId,
+        message.toAgentId,
+        message.fromAgentId,
+        'inbound',
+        replyToMessageId
+      );
+      return true;
+    } catch (error) {
+      this.logger.warn('Failed to persist message history', {
+        messageId: message.messageId,
+        error: getErrorMessage(error),
+      });
+      return false;
+    }
   }
 
   /**
@@ -181,13 +293,17 @@ export class MessageHandler {
           // RFC 013: 将 noReply 放入 metadata，让接收方知道不需要回复
           // RFC 013: 将 noReplyReason 放入 metadata，提供不期待回复的原因
           // 使用计算后的 finalNoReply 值
+          const conversationId = await this.resolveConversationId(data);
+          const messageId = randomUUID();
           const message: RoutableMessage = {
-            messageId: randomUUID(),
+            messageId,
             fromAgentId: data.fromAgentId,
             toAgentId: data.toAgentId,
             content: data.content,
             metadata: {
               ...data.metadata,
+              conversationId,
+              replyToMessageId: data.replyToMessageId,
               // RFC 013: 标记消息是否需要回复（默认 true = 不需要回复）
               noReply: finalNoReply,
               // RFC 013: 可选的不期待回复的原因
@@ -212,6 +328,11 @@ export class MessageHandler {
 
             const routed = await this.messageRouter.routeAsync(message);
             if (routed) {
+              const historyPersisted = await this.persistMessage(
+                message,
+                conversationId,
+                data.replyToMessageId
+              );
               this.logger.debug('Message routed', {
                 messageId: message.messageId,
                 fromAgentId: data.fromAgentId,
@@ -221,6 +342,8 @@ export class MessageHandler {
               res.end(JSON.stringify({
                 success: true,
                 messageId: message.messageId,
+                conversationId,
+                historyPersisted,
               }));
             } else {
               res.writeHead(500);
@@ -233,10 +356,17 @@ export class MessageHandler {
           } else {
             // 广播消息
             const broadcasted = await this.messageRouter.broadcastAsync(message);
+            const historyPersisted = await this.persistMessage(
+              message,
+              conversationId,
+              data.replyToMessageId
+            );
             res.writeHead(200);
             res.end(JSON.stringify({
               success: true,
               messageId: message.messageId,
+              conversationId,
+              historyPersisted,
               broadcasted,
             }));
           }
@@ -288,6 +418,40 @@ export class MessageHandler {
     // 解析查询参数
     const url = new URL(req.url || '', `http://localhost`);
     const limit = parseInt(url.searchParams.get('limit') || '50', 10);
+    const conversationId = url.searchParams.get('conversationId') || undefined;
+    const peerAgentId = url.searchParams.get('peerAgentId') || undefined;
+
+    if ((conversationId || peerAgentId) && this.messageStore) {
+      (async () => {
+        try {
+          const messages = conversationId
+            ? await this.messageStore!.getByConversation(agentId, conversationId, limit)
+            : (await this.messageStore!.getByAgent(agentId, limit))
+                .filter(message => message.peerAgentId === peerAgentId);
+
+          res.writeHead(200);
+          res.end(JSON.stringify({
+            success: true,
+            agentId,
+            messages,
+            count: messages.length,
+            source: 'history',
+          }));
+        } catch (error) {
+          this.logger.error('Failed to get message history', {
+            agentId,
+            error: getErrorMessage(error),
+          });
+          res.writeHead(500);
+          res.end(JSON.stringify({
+            success: false,
+            error: 'Failed to get message history',
+            code: 'MESSAGE_HISTORY_FAILED',
+          }));
+        }
+      })();
+      return;
+    }
 
     // 获取消息
     const messages = this.messageRouter.getMessages(agentId, limit);
@@ -299,6 +463,61 @@ export class MessageHandler {
       messages,
       count: messages.length,
     }));
+  }
+
+  /**
+   * 获取 Agent 的会话摘要列表
+   * GET /api/v1/conversations/:agentId
+   */
+  handleListConversations(agentId: string, req: IncomingMessage, res: ServerResponse): void {
+    if (!this.agentRegistry.get(agentId)) {
+      res.writeHead(404);
+      res.end(JSON.stringify({
+        success: false,
+        error: 'Agent not found',
+        code: 'AGENT_NOT_FOUND',
+      }));
+      return;
+    }
+
+    if (!this.messageStore) {
+      res.writeHead(500);
+      res.end(JSON.stringify({
+        success: false,
+        error: 'Message history store not configured',
+        code: 'MESSAGE_HISTORY_FAILED',
+      }));
+      return;
+    }
+
+    this.agentRegistry.updateLastActive(agentId);
+
+    const url = new URL(req.url || '', `http://localhost`);
+    const limit = parseInt(url.searchParams.get('limit') || '50', 10);
+
+    (async () => {
+      try {
+        const conversations = await this.messageStore!.listConversations(agentId, limit);
+        res.writeHead(200);
+        res.end(JSON.stringify({
+          success: true,
+          agentId,
+          conversations,
+          count: conversations.length,
+        }));
+      } catch (error) {
+        this.logger.error('Failed to list conversations', {
+          agentId,
+          error: getErrorMessage(error),
+        });
+        res.writeHead(500);
+        res.end(JSON.stringify({
+          success: false,
+          error: 'Failed to list conversations',
+          code: 'MESSAGE_HISTORY_FAILED',
+        }));
+      }
+    })();
   }
 
   /**

--- a/packages/daemon/src/types/handlers.ts
+++ b/packages/daemon/src/types/handlers.ts
@@ -14,6 +14,7 @@ import type {
   AgentRegistry,
   AgentRegistration,
   MessageRouter,
+  MessageStore,
   F2A,
   E2EECrypto,
   ChallengeStore
@@ -97,6 +98,7 @@ export interface MessageHandlerDeps extends HandlerDeps {
   agentRegistry: AgentRegistry;
   f2a: F2A;
   agentTokenManager: AgentTokenManager;
+  messageStore?: MessageStore;
 }
 
 /**

--- a/packages/daemon/tests/conversation-history.integration.test.ts
+++ b/packages/daemon/tests/conversation-history.integration.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Conversation Layer 最小集成测试
+ *
+ * 覆盖真实 ControlServer HTTP API、Agent 注册、消息发送、会话历史查询和重启后持久化读取。
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { createServer } from 'net';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { ControlServer } from '../src/control-server.js';
+import {
+  AgentIdentityKeypair,
+  F2A,
+  generateAgentId,
+  signSelfSignature,
+} from '@f2a/network';
+
+async function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once('error', reject);
+    server.listen(0, () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close(() => reject(new Error('Failed to allocate test port')));
+        return;
+      }
+      const { port } = address;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+async function createF2A(dataDir: string): Promise<F2A> {
+  return F2A.create({
+    dataDir,
+    displayName: 'Conversation Integration Test',
+    network: {
+      listenPort: 0,
+      enableMDNS: false,
+      enableDHT: false,
+    },
+    logLevel: 'ERROR',
+  });
+}
+
+function createAgentIdentity(name: string): { name: string; publicKey: string; selfSignature: string } {
+  const keypair = new AgentIdentityKeypair().generateKeypair();
+  const agentId = generateAgentId(keypair.publicKey);
+  return {
+    name,
+    publicKey: keypair.publicKey,
+    selfSignature: signSelfSignature(agentId, keypair.publicKey, keypair.privateKey),
+  };
+}
+
+async function postJson<T>(
+  baseUrl: string,
+  path: string,
+  body: unknown,
+  headers: Record<string, string> = {}
+): Promise<T> {
+  const response = await fetch(`${baseUrl}${path}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+  const json = await response.json() as T;
+
+  if (!response.ok) {
+    throw new Error(`POST ${path} failed with ${response.status}: ${JSON.stringify(json)}`);
+  }
+
+  return json;
+}
+
+async function getJson<T>(baseUrl: string, path: string): Promise<T> {
+  const response = await fetch(`${baseUrl}${path}`);
+  const json = await response.json() as T;
+
+  if (!response.ok) {
+    throw new Error(`GET ${path} failed with ${response.status}: ${JSON.stringify(json)}`);
+  }
+
+  return json;
+}
+
+describe('Conversation history integration', () => {
+  let server: ControlServer | undefined;
+  let dataDir: string | undefined;
+
+  afterEach(() => {
+    server?.stop();
+    server = undefined;
+
+    if (dataDir) {
+      rmSync(dataDir, { recursive: true, force: true });
+      dataDir = undefined;
+    }
+  });
+
+  it('persists conversation history across ControlServer restarts', async () => {
+    dataDir = mkdtempSync(join(tmpdir(), 'f2a-conversation-integration-'));
+    const port = await getFreePort();
+    const baseUrl = `http://127.0.0.1:${port}`;
+    const conversationId = 'conv-integration-minimal';
+
+    const firstF2A = await createF2A(dataDir);
+    server = new ControlServer(firstF2A, port, undefined, { dataDir });
+    await server.start();
+
+    const aliceIdentity = createAgentIdentity('Alice');
+    const bobIdentity = createAgentIdentity('Bob');
+
+    const aliceRegistration = await postJson<{
+      success: boolean;
+      agent: { agentId: string };
+      token: string;
+    }>(baseUrl, '/api/v1/agents', {
+      name: aliceIdentity.name,
+      publicKey: aliceIdentity.publicKey,
+      selfSignature: aliceIdentity.selfSignature,
+      capabilities: ['chat'],
+      webhook: { url: 'http://127.0.0.1:65535/alice-webhook' },
+    });
+    const bobRegistration = await postJson<{
+      success: boolean;
+      agent: { agentId: string };
+      token: string;
+    }>(baseUrl, '/api/v1/agents', {
+      name: bobIdentity.name,
+      publicKey: bobIdentity.publicKey,
+      selfSignature: bobIdentity.selfSignature,
+      capabilities: ['chat'],
+      webhook: { url: 'http://127.0.0.1:65535/bob-webhook' },
+    });
+
+    expect(aliceRegistration.success).toBe(true);
+    expect(bobRegistration.success).toBe(true);
+
+    firstF2A.getAgentRegistry().get(aliceRegistration.agent.agentId)!.webhook = undefined;
+    firstF2A.getAgentRegistry().get(bobRegistration.agent.agentId)!.webhook = undefined;
+
+    const sendResult = await postJson<{
+      success: boolean;
+      messageId: string;
+      conversationId: string;
+      historyPersisted: boolean;
+    }>(baseUrl, '/api/v1/messages', {
+      fromAgentId: aliceRegistration.agent.agentId,
+      toAgentId: bobRegistration.agent.agentId,
+      content: 'hello from integration',
+      conversationId,
+      expectReply: false,
+    }, {
+      Authorization: aliceRegistration.token,
+    });
+
+    expect(sendResult).toMatchObject({
+      success: true,
+      conversationId,
+      historyPersisted: true,
+    });
+
+    const aliceConversations = await getJson<{
+      success: boolean;
+      conversations: Array<{ conversationId: string; peerAgentId: string; messageCount: number }>;
+    }>(baseUrl, `/api/v1/conversations/${encodeURIComponent(aliceRegistration.agent.agentId)}`);
+    const bobHistory = await getJson<{
+      success: boolean;
+      source: string;
+      messages: Array<{ conversationId: string; direction: string; content?: string; summary?: string }>;
+    }>(
+      baseUrl,
+      `/api/v1/messages/${encodeURIComponent(bobRegistration.agent.agentId)}?conversationId=${encodeURIComponent(conversationId)}`
+    );
+
+    expect(aliceConversations.conversations).toContainEqual(expect.objectContaining({
+      conversationId,
+      peerAgentId: bobRegistration.agent.agentId,
+      messageCount: 1,
+    }));
+    expect(bobHistory).toMatchObject({
+      success: true,
+      source: 'history',
+    });
+    expect(bobHistory.messages).toHaveLength(1);
+    expect(bobHistory.messages[0]).toMatchObject({
+      conversationId,
+      direction: 'inbound',
+      summary: 'hello from integration',
+    });
+
+    server.stop();
+    server = undefined;
+
+    const secondF2A = await createF2A(dataDir);
+    server = new ControlServer(secondF2A, port, undefined, { dataDir });
+    await server.start();
+
+    const persistedBobHistory = await getJson<{
+      success: boolean;
+      source: string;
+      messages: Array<{ conversationId: string; direction: string; summary?: string }>;
+    }>(
+      baseUrl,
+      `/api/v1/messages/${encodeURIComponent(bobRegistration.agent.agentId)}?conversationId=${encodeURIComponent(conversationId)}`
+    );
+
+    expect(persistedBobHistory).toMatchObject({
+      success: true,
+      source: 'history',
+    });
+    expect(persistedBobHistory.messages).toHaveLength(1);
+    expect(persistedBobHistory.messages[0]).toMatchObject({
+      conversationId,
+      direction: 'inbound',
+      summary: 'hello from integration',
+    });
+  }, 30000);
+});

--- a/packages/network/src/core/message-router.test.ts
+++ b/packages/network/src/core/message-router.test.ts
@@ -315,6 +315,25 @@ describe('MessageRouter', () => {
       expect(queue?.messages[0].content).toBe('incoming message');
     });
 
+    it('should route incoming message when remote sender is not locally registered', async () => {
+      agentRegistry.delete('agent:remote');
+
+      const payload = {
+        messageId: 'msg-remote-unregistered',
+        fromAgentId: 'agent:remote',
+        toAgentId: 'agent:receiver',
+        content: 'remote sender should not need local registration',
+        type: 'message',
+      };
+
+      await router.routeIncoming(payload, '12D3KooWRemotePeer');
+
+      const queue = router.getQueue('agent:receiver');
+      expect(queue?.messages.length).toBe(1);
+      expect(queue?.messages[0].messageId).toBe('msg-remote-unregistered');
+      expect(queue?.messages[0].fromAgentId).toBe('agent:remote');
+    });
+
     it('should emit message:received event on success', async () => {
       const handler = vi.fn();
       router.on('message:received', handler);

--- a/packages/network/src/core/message-router.ts
+++ b/packages/network/src/core/message-router.ts
@@ -679,8 +679,8 @@ export class MessageRouter extends EventEmitter<MessageRouterEvents> {
 
     if (targetAgent) {
       // 目标 Agent 在本地
-      // 使用 routeAsync 进行完整路由(包含 webhook)
-      const routed = await this.routeAsync(routableMessage);
+      // 入站消息的发送方通常是远程 Agent，不要求其在本地注册表存在。
+      const routed = await this.routeIncomingToLocalAgent(routableMessage, targetAgent);
       if (routed) {
         this.logger.info('Incoming message routed to local Agent', {
           messageId: routableMessage.messageId,
@@ -708,6 +708,77 @@ export class MessageRouter extends EventEmitter<MessageRouterEvents> {
         agentId: message.toAgentId,
       });
     }
+  }
+
+  /**
+   * 路由远程入站消息到本地 Agent。
+   *
+   * 与 routeAsync() 不同，这里不校验 fromAgentId 是否在本地注册表中；
+   * 远程发送方身份应由 P2P/AgentId 验证链路负责。
+   */
+  private async routeIncomingToLocalAgent(
+    message: RoutableMessage,
+    targetAgent: AgentRegistration
+  ): Promise<boolean> {
+    const { toAgentId, fromAgentId } = message;
+
+    if (!toAgentId) {
+      return false;
+    }
+
+    if (targetAgent.onMessage) {
+      try {
+        targetAgent.onMessage({
+          messageId: message.messageId,
+          fromAgentId: message.fromAgentId,
+          toAgentId,
+          content: message.content,
+          type: message.type,
+          createdAt: message.createdAt,
+        });
+        this.logger.debug('Incoming message delivered via local callback', {
+          messageId: message.messageId,
+          toAgentId,
+          fromAgentId,
+        });
+        return true;
+      } catch (err) {
+        this.logger.error('Incoming local callback error', {
+          toAgentId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    if (targetAgent.webhook?.url) {
+      const webhookResult = await this.webhookPusher.forwardToAgentWebhook(message, targetAgent);
+      if (webhookResult.success) {
+        this.logger.info('Incoming message forwarded to Agent webhook', {
+          messageId: message.messageId,
+          toAgentId,
+          webhookUrl: targetAgent.webhook.url,
+        });
+        return true;
+      }
+      this.logger.warn('Incoming Agent webhook forwarding failed, falling back to queue', {
+        toAgentId,
+        error: webhookResult.error,
+      });
+    }
+
+    const queue = this.queueManager.getQueue(toAgentId);
+    if (!queue) {
+      this.logger.warn('Incoming target agent queue not found', { toAgentId });
+      return false;
+    }
+
+    this.queueManager.enqueue(queue, message);
+    this.logger.debug('Incoming message routed to queue', {
+      messageId: message.messageId,
+      toAgentId,
+      fromAgentId,
+    });
+    return true;
   }
 
   /**

--- a/packages/network/src/core/message-store.test.ts
+++ b/packages/network/src/core/message-store.test.ts
@@ -232,6 +232,81 @@ describe('MessageStore', () => {
     });
   });
 
+  describe('conversation queries', () => {
+    it('应该保存并按 conversationId 查询消息', async () => {
+      await store.add(createMessageRecord(
+        'msg-1',
+        'agent:alice',
+        'agent:bob',
+        'message',
+        Date.now(),
+        'hello',
+        { content: 'hello' },
+        {
+          conversationId: 'conv-1',
+          replyToMessageId: undefined,
+          direction: 'outbound',
+          agentId: 'agent:alice',
+          peerAgentId: 'agent:bob',
+          metadata: { noReply: false }
+        }
+      ));
+
+      const messages = await store.getByConversation('agent:alice', 'conv-1');
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0].conversationId).toBe('conv-1');
+      expect(messages[0].agentId).toBe('agent:alice');
+      expect(messages[0].peerAgentId).toBe('agent:bob');
+      expect(messages[0].metadata).toBe(JSON.stringify({ noReply: false }));
+    });
+
+    it('应该返回 Agent 的会话摘要列表', async () => {
+      await store.add(createMessageRecord(
+        'msg-1',
+        'agent:alice',
+        'agent:bob',
+        'message',
+        1000,
+        'first',
+        { content: 'first' },
+        {
+          conversationId: 'conv-1',
+          direction: 'outbound',
+          agentId: 'agent:alice',
+          peerAgentId: 'agent:bob'
+        }
+      ));
+      await store.add(createMessageRecord(
+        'msg-2',
+        'agent:bob',
+        'agent:alice',
+        'message',
+        2000,
+        'second',
+        { content: 'second' },
+        {
+          conversationId: 'conv-1',
+          direction: 'inbound',
+          agentId: 'agent:alice',
+          peerAgentId: 'agent:bob'
+        }
+      ));
+
+      const conversations = await store.listConversations('agent:alice');
+
+      expect(conversations).toEqual([
+        {
+          conversationId: 'conv-1',
+          peerAgentId: 'agent:bob',
+          lastMessageAt: 2000,
+          messageCount: 2,
+          lastSummary: 'second'
+        }
+      ]);
+    });
+  });
+
   describe('clear', () => {
     it('应该清空所有消息记录', async () => {
       for (let i = 0; i < 10; i++) {

--- a/packages/network/src/core/message-store.test.ts
+++ b/packages/network/src/core/message-store.test.ts
@@ -305,6 +305,51 @@ describe('MessageStore', () => {
         }
       ]);
     });
+
+    it('时间戳相同时会话摘要不应因 JOIN 产生重复行', async () => {
+      await store.add(createMessageRecord(
+        'msg-1',
+        'agent:alice',
+        'agent:bob',
+        'message',
+        1000,
+        'first',
+        { content: 'first' },
+        {
+          conversationId: 'conv-1',
+          direction: 'outbound',
+          agentId: 'agent:alice',
+          peerAgentId: 'agent:bob'
+        }
+      ));
+      await store.add(createMessageRecord(
+        'msg-2',
+        'agent:bob',
+        'agent:alice',
+        'message',
+        1000,
+        'second',
+        { content: 'second' },
+        {
+          conversationId: 'conv-1',
+          direction: 'inbound',
+          agentId: 'agent:alice',
+          peerAgentId: 'agent:bob'
+        }
+      ));
+
+      const conversations = await store.listConversations('agent:alice');
+
+      expect(conversations).toEqual([
+        {
+          conversationId: 'conv-1',
+          peerAgentId: 'agent:bob',
+          lastMessageAt: 1000,
+          messageCount: 2,
+          lastSummary: 'second'
+        }
+      ]);
+    });
   });
 
   describe('clear', () => {

--- a/packages/network/src/core/message-store.ts
+++ b/packages/network/src/core/message-store.ts
@@ -187,6 +187,8 @@ export class MessageStore implements IMessageStore {
       CREATE INDEX IF NOT EXISTS idx_messages_agent_id ON messages(agent_id);
       CREATE INDEX IF NOT EXISTS idx_messages_peer_agent_id ON messages(peer_agent_id);
       CREATE INDEX IF NOT EXISTS idx_messages_created_at ON messages(created_at);
+      CREATE INDEX IF NOT EXISTS idx_messages_agent_conversation_peer_time
+        ON messages(agent_id, conversation_id, peer_agent_id, timestamp);
     `);
   }
 
@@ -353,28 +355,44 @@ export class MessageStore implements IMessageStore {
    */
   async listConversations(agentId: string, limit: number = 50): Promise<ConversationSummary[]> {
     const stmt = this.db.prepare(`
+      WITH conversation_stats AS (
+        SELECT
+          conversation_id,
+          peer_agent_id,
+          MAX(timestamp) as lastMessageAt,
+          COUNT(*) as messageCount
+        FROM messages
+        WHERE agent_id = ? AND conversation_id IS NOT NULL
+        GROUP BY conversation_id, peer_agent_id
+      ),
+      latest_message AS (
+        SELECT
+          conversation_id,
+          peer_agent_id,
+          summary,
+          ROW_NUMBER() OVER (
+            PARTITION BY conversation_id, peer_agent_id
+            ORDER BY timestamp DESC, rowid DESC
+          ) as rowNumber
+        FROM messages
+        WHERE agent_id = ? AND conversation_id IS NOT NULL
+      )
       SELECT
-        conversation_id as conversationId,
-        peer_agent_id as peerAgentId,
-        MAX(timestamp) as lastMessageAt,
-        COUNT(*) as messageCount,
-        (
-          SELECT m2.summary
-          FROM messages m2
-          WHERE m2.agent_id = messages.agent_id
-            AND m2.conversation_id = messages.conversation_id
-            AND m2.peer_agent_id = messages.peer_agent_id
-          ORDER BY m2.timestamp DESC
-          LIMIT 1
-        ) as lastSummary
-      FROM messages
-      WHERE agent_id = ? AND conversation_id IS NOT NULL
-      GROUP BY conversation_id, peer_agent_id
-      ORDER BY lastMessageAt DESC
+        cs.conversation_id as conversationId,
+        cs.peer_agent_id as peerAgentId,
+        cs.lastMessageAt,
+        cs.messageCount,
+        lm.summary as lastSummary
+      FROM conversation_stats cs
+      LEFT JOIN latest_message lm
+        ON lm.conversation_id = cs.conversation_id
+       AND lm.peer_agent_id = cs.peer_agent_id
+       AND lm.rowNumber = 1
+      ORDER BY cs.lastMessageAt DESC
       LIMIT ?
     `);
 
-    const rows = stmt.all(agentId, limit) as Array<{
+    const rows = stmt.all(agentId, agentId, limit) as Array<{
       conversationId: string;
       peerAgentId: string;
       lastMessageAt: number;

--- a/packages/network/src/core/message-store.ts
+++ b/packages/network/src/core/message-store.ts
@@ -29,7 +29,37 @@ export interface MessageRecord {
   /** 消息摘要（可选） */
   summary?: string;
   /** JSON 序列化的 payload（可选） */
-  payload?: string;
+  payload?: string | null;
+  /** 会话 ID（可选） */
+  conversationId?: string;
+  /** 回复的消息 ID（可选） */
+  replyToMessageId?: string;
+  /** 本地视角下的消息方向 */
+  direction?: 'inbound' | 'outbound' | 'local';
+  /** 本地视角 Agent ID */
+  agentId?: string;
+  /** 对方 Agent ID */
+  peerAgentId?: string;
+  /** JSON 序列化的 metadata（可选） */
+  metadata?: string;
+  /** 创建时间（毫秒，兼容 timestamp） */
+  createdAt?: number;
+}
+
+/**
+ * 会话摘要
+ */
+export interface ConversationSummary {
+  /** 会话 ID */
+  conversationId: string;
+  /** 对方 Agent ID */
+  peerAgentId: string;
+  /** 最后一条消息时间 */
+  lastMessageAt: number;
+  /** 消息数量 */
+  messageCount: number;
+  /** 最后一条消息摘要 */
+  lastSummary?: string;
 }
 
 /**
@@ -42,6 +72,12 @@ export interface IMessageStore {
   getRecent(limit?: number): Promise<MessageRecord[]>;
   /** 获取与特定 Agent 相关的消息记录 */
   getByAgent(agentId: string, limit?: number): Promise<MessageRecord[]>;
+  /** 获取指定会话的消息记录 */
+  getByConversation(agentId: string, conversationId: string, limit?: number): Promise<MessageRecord[]>;
+  /** 获取指定消息 */
+  getByMessageId(messageId: string): Promise<MessageRecord | undefined>;
+  /** 获取 Agent 的会话摘要列表 */
+  listConversations(agentId: string, limit?: number): Promise<ConversationSummary[]>;
   /** 清空所有消息记录 */
   clear(): Promise<void>;
   /** 关闭数据库连接 */
@@ -137,6 +173,57 @@ export class MessageStore implements IMessageStore {
       CREATE INDEX IF NOT EXISTS idx_messages_to ON messages("to");
       CREATE INDEX IF NOT EXISTS idx_messages_type ON messages(type);
     `);
+
+    this.ensureColumn('messages', 'conversation_id', 'TEXT');
+    this.ensureColumn('messages', 'reply_to_message_id', 'TEXT');
+    this.ensureColumn('messages', 'direction', 'TEXT');
+    this.ensureColumn('messages', 'agent_id', 'TEXT');
+    this.ensureColumn('messages', 'peer_agent_id', 'TEXT');
+    this.ensureColumn('messages', 'metadata', 'TEXT');
+    this.ensureColumn('messages', 'created_at', 'INTEGER');
+
+    this.db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_messages_conversation_id ON messages(conversation_id);
+      CREATE INDEX IF NOT EXISTS idx_messages_agent_id ON messages(agent_id);
+      CREATE INDEX IF NOT EXISTS idx_messages_peer_agent_id ON messages(peer_agent_id);
+      CREATE INDEX IF NOT EXISTS idx_messages_created_at ON messages(created_at);
+    `);
+  }
+
+  /**
+   * 幂等补充列，用于兼容旧 messages.db
+   */
+  private ensureColumn(tableName: string, columnName: string, columnType: string): void {
+    const columns = this.db.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{ name: string }>;
+    if (columns.some(column => column.name === columnName)) {
+      return;
+    }
+    this.db.exec(`ALTER TABLE ${tableName} ADD COLUMN ${columnName} ${columnType}`);
+  }
+
+  /**
+   * 将数据库行转换为 MessageRecord，避免旧调用方看到 null 扩展字段
+   */
+  private rowToRecord(row: Record<string, unknown>): MessageRecord {
+    const record: MessageRecord = {
+      id: row.id as string,
+      from: row.from as string,
+      to: row.to as string,
+      type: row.type as string,
+      timestamp: row.timestamp as number,
+    };
+
+    if (row.summary !== null && row.summary !== undefined) record.summary = row.summary as string;
+    if (row.payload !== undefined) record.payload = row.payload as string | null;
+    if (row.conversation_id !== null && row.conversation_id !== undefined) record.conversationId = row.conversation_id as string;
+    if (row.reply_to_message_id !== null && row.reply_to_message_id !== undefined) record.replyToMessageId = row.reply_to_message_id as string;
+    if (row.direction !== null && row.direction !== undefined) record.direction = row.direction as MessageRecord['direction'];
+    if (row.agent_id !== null && row.agent_id !== undefined) record.agentId = row.agent_id as string;
+    if (row.peer_agent_id !== null && row.peer_agent_id !== undefined) record.peerAgentId = row.peer_agent_id as string;
+    if (row.metadata !== null && row.metadata !== undefined) record.metadata = row.metadata as string;
+    if (row.created_at !== null && row.created_at !== undefined) record.createdAt = row.created_at as number;
+
+    return record;
   }
 
   /**
@@ -145,8 +232,12 @@ export class MessageStore implements IMessageStore {
    */
   async add(message: MessageRecord): Promise<void> {
     const stmt = this.db.prepare(`
-      INSERT INTO messages (id, "from", "to", type, timestamp, summary, payload)
-      VALUES (?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO messages (
+        id, "from", "to", type, timestamp, summary, payload,
+        conversation_id, reply_to_message_id, direction, agent_id, peer_agent_id,
+        metadata, created_at
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     stmt.run(
@@ -156,7 +247,14 @@ export class MessageStore implements IMessageStore {
       message.type,
       message.timestamp,
       message.summary || null,
-      message.payload || null
+      message.payload || null,
+      message.conversationId || null,
+      message.replyToMessageId || null,
+      message.direction || null,
+      message.agentId || null,
+      message.peerAgentId || null,
+      message.metadata || null,
+      message.createdAt || message.timestamp
     );
 
     // 检查是否需要清理
@@ -181,8 +279,8 @@ export class MessageStore implements IMessageStore {
       LIMIT ?
     `);
 
-    const rows = stmt.all(limit) as MessageRecord[];
-    return rows;
+    const rows = stmt.all(limit) as Array<Record<string, unknown>>;
+    return rows.map(row => this.rowToRecord(row));
   }
 
   /**
@@ -192,15 +290,105 @@ export class MessageStore implements IMessageStore {
    */
   async getByAgent(agentId: string, limit: number = 100): Promise<MessageRecord[]> {
     const stmt = this.db.prepare(`
-      SELECT id, "from", "to", type, timestamp, summary, payload
+      SELECT id, "from", "to", type, timestamp, summary, payload,
+             conversation_id, reply_to_message_id, direction, agent_id,
+             peer_agent_id, metadata, created_at
       FROM messages
-      WHERE "from" = ? OR "to" = ?
+      WHERE "from" = ? OR "to" = ? OR agent_id = ?
       ORDER BY timestamp DESC
       LIMIT ?
     `);
 
-    const rows = stmt.all(agentId, agentId, limit) as MessageRecord[];
-    return rows;
+    const rows = stmt.all(agentId, agentId, agentId, limit) as Array<Record<string, unknown>>;
+    return rows.map(row => this.rowToRecord(row));
+  }
+
+  /**
+   * 获取指定会话的消息记录
+   * @param agentId 本地视角 Agent ID
+   * @param conversationId 会话 ID
+   * @param limit 限制数量（默认 100）
+   */
+  async getByConversation(
+    agentId: string,
+    conversationId: string,
+    limit: number = 100
+  ): Promise<MessageRecord[]> {
+    const stmt = this.db.prepare(`
+      SELECT id, "from", "to", type, timestamp, summary, payload,
+             conversation_id, reply_to_message_id, direction, agent_id,
+             peer_agent_id, metadata, created_at
+      FROM messages
+      WHERE agent_id = ? AND conversation_id = ?
+      ORDER BY timestamp ASC
+      LIMIT ?
+    `);
+
+    const rows = stmt.all(agentId, conversationId, limit) as Array<Record<string, unknown>>;
+    return rows.map(row => this.rowToRecord(row));
+  }
+
+  /**
+   * 获取指定消息
+   * @param messageId 消息 ID
+   */
+  async getByMessageId(messageId: string): Promise<MessageRecord | undefined> {
+    const stmt = this.db.prepare(`
+      SELECT id, "from", "to", type, timestamp, summary, payload,
+             conversation_id, reply_to_message_id, direction, agent_id,
+             peer_agent_id, metadata, created_at
+      FROM messages
+      WHERE id = ?
+      LIMIT 1
+    `);
+
+    const row = stmt.get(messageId) as Record<string, unknown> | undefined;
+    return row ? this.rowToRecord(row) : undefined;
+  }
+
+  /**
+   * 获取 Agent 的会话摘要列表
+   * @param agentId 本地视角 Agent ID
+   * @param limit 限制数量（默认 50）
+   */
+  async listConversations(agentId: string, limit: number = 50): Promise<ConversationSummary[]> {
+    const stmt = this.db.prepare(`
+      SELECT
+        conversation_id as conversationId,
+        peer_agent_id as peerAgentId,
+        MAX(timestamp) as lastMessageAt,
+        COUNT(*) as messageCount,
+        (
+          SELECT m2.summary
+          FROM messages m2
+          WHERE m2.agent_id = messages.agent_id
+            AND m2.conversation_id = messages.conversation_id
+            AND m2.peer_agent_id = messages.peer_agent_id
+          ORDER BY m2.timestamp DESC
+          LIMIT 1
+        ) as lastSummary
+      FROM messages
+      WHERE agent_id = ? AND conversation_id IS NOT NULL
+      GROUP BY conversation_id, peer_agent_id
+      ORDER BY lastMessageAt DESC
+      LIMIT ?
+    `);
+
+    const rows = stmt.all(agentId, limit) as Array<{
+      conversationId: string;
+      peerAgentId: string;
+      lastMessageAt: number;
+      messageCount: number;
+      lastSummary: string | null;
+    }>;
+
+    return rows.map(row => ({
+      conversationId: row.conversationId,
+      peerAgentId: row.peerAgentId,
+      lastMessageAt: row.lastMessageAt,
+      messageCount: row.messageCount,
+      ...(row.lastSummary !== null ? { lastSummary: row.lastSummary } : {})
+    }));
   }
 
   /**
@@ -314,7 +502,16 @@ export function createMessageRecord(
   type: string,
   timestamp: number,
   summary?: string,
-  payload?: unknown
+  payload?: unknown,
+  options?: {
+    conversationId?: string;
+    replyToMessageId?: string;
+    direction?: 'inbound' | 'outbound' | 'local';
+    agentId?: string;
+    peerAgentId?: string;
+    metadata?: unknown;
+    createdAt?: number;
+  }
 ): MessageRecord {
   return {
     id,
@@ -323,6 +520,13 @@ export function createMessageRecord(
     type,
     timestamp,
     summary,
-    payload: payload ? JSON.stringify(payload) : undefined
+    payload: payload ? JSON.stringify(payload) : undefined,
+    conversationId: options?.conversationId,
+    replyToMessageId: options?.replyToMessageId,
+    direction: options?.direction,
+    agentId: options?.agentId,
+    peerAgentId: options?.peerAgentId,
+    metadata: options?.metadata ? JSON.stringify(options.metadata) : undefined,
+    createdAt: options?.createdAt
   };
 }

--- a/packages/network/src/index.ts
+++ b/packages/network/src/index.ts
@@ -68,6 +68,8 @@ export { AgentRegistry, AgentRegistration } from './core/agent-registry.js';
 export type { AgentRegistryOptions, AgentWebhook, MessageCallback } from './core/agent-registry.js';
 export { MessageRouter, RoutableMessage } from './core/message-router.js';
 export type { MessageQueue, MessageRouterEvents } from './core/message-router.js';
+export { MessageStore, createMessageRecord } from './core/message-store.js';
+export type { ConversationSummary, MessageRecord } from './core/message-store.js';
 
 // 信誉系统 (Phase 1-4)
 export { ReputationManager, REPUTATION_TIERS } from './core/reputation.js';

--- a/packages/openclaw-f2a/package.json
+++ b/packages/openclaw-f2a/package.json
@@ -15,7 +15,7 @@
     "prepack": "cp -r ../../skills ./skills"
   },
   "dependencies": {
-    "@f2a/network": "^0.7.5",
+    "@f2a/network": "*",
     "eventemitter3": "^5.0.4",
     "zod": "^3.22.4"
   },


### PR DESCRIPTION
## Summary
- Add SQLite-backed conversation history to `MessageStore`, including conversation lookup and summaries.
- Persist Daemon send-chain messages with `conversationId` and `replyToMessageId`, and expose CLI commands for conversation and thread queries.
- Route P2P inbound messages into the same history store so remote messages are queryable as local conversation history.
- Update OpenClaw workspace dependency resolution and add supporting docs and implementation planning notes.

## Testing
- Added and updated unit tests for `MessageStore`, `MessageHandler`, `ControlServer`, and CLI message commands.
- Added coverage for P2P inbound routing and conversation-history persistence.
- `lint` and targeted package tests passed locally.